### PR TITLE
DOC: redirect tox doc to doc/_build/html

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,4 +34,4 @@ commands =
 description = Check if documentation generates properly
 extras = doc
 commands =
-    sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxworkdir}/doc_out" --color -vW -bhtml
+    sphinx-build -d "{toxworkdir}/doc_doctree" doc/source ""{toxinidir}/doc/_build/html" --color -vW -bhtml


### PR DESCRIPTION
This pull-request ensures that the rendered HTML documentation files are placed in the `doc/_build/html` directory.