### PR TITLE
FIX: syntax in tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -34,4 +34,4 @@ commands =
 description = Check if documentation generates properly
 extras = doc
 commands =
-    sphinx-build -d "{toxworkdir}/doc_doctree" doc/source ""{toxinidir}/doc/_build/html" --color -vW -bhtml
+    sphinx-build -d "{toxworkdir}/doc_doctree" doc/source "{toxinidir}/doc/_build/html" --color -vW -bhtml


### PR DESCRIPTION
As noted by @PipKat, there is a syntax error in the `tox.ini` file. This pull-request fixes this error.