### PR TITLE
Update parts list from AVL: fix unit tests, include classes for enums in API docs

### DIFF
--- a/doc/source/api/parts_types.rst
+++ b/doc/source/api/parts_types.rst
@@ -7,6 +7,10 @@ Parts Types
 
 Constants
 ---------
+.. autoclass:: AVLDescription
+     :members:
+.. autoclass:: AVLPartNum
+     :members:
 .. autoclass:: PartsListSearchDuplicationMode
      :members:
 .. autoclass:: PartsListSearchMatchingMode

--- a/src/ansys/sherlock/core/types/parts_types.py
+++ b/src/ansys/sherlock/core/types/parts_types.py
@@ -32,17 +32,22 @@ class AVLPartNum:
     """Constants for AVLPartNum in the Update Parts List from AVL request."""
 
     ASSIGN_INTERNAL_PART_NUM = SherlockPartsService_pb2.AVLPartNum.AssignInternalPartNum
+    """AssignInternalPartNum"""
     ASSIGN_VENDOR_AND_PART_NUM = SherlockPartsService_pb2.AVLPartNum.AssignVendorAndPartNum
+    """AssignVendorAndPartNum"""
     DO_NOT_CHANGE_VENDOR_OR_PART_NUM = (
         SherlockPartsService_pb2.AVLPartNum.DoNotChangeVendorOrPartNum
     )
+    """DoNotChangeVendorOrPartNum"""
 
 
 class AVLDescription:
     """Constants for AVLDescription in the Update Parts List from AVL request."""
 
     ASSIGN_APPROVED_DESCRIPTION = SherlockPartsService_pb2.AVLDescription.AssignApprovedDescription
+    """AssignApprovedDescription"""
     DO_NOT_CHANGE_DESCRIPTION = SherlockPartsService_pb2.AVLDescription.DoNotChangeDescription
+    """DoNotChangeDescription"""
 
 
 class PartLocation:

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -33,6 +33,7 @@ def test_all():
     parts = Parts(channel)
 
     helper_test_update_parts_list(parts)
+    time.sleep(1)
     helper_test_update_parts_from_AVL(parts)
     helper_test_update_parts_locations(parts)
     helper_test_update_parts_locations_by_file(parts)
@@ -135,58 +136,6 @@ def helper_test_update_parts_from_AVL(parts):
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockUpdatePartsFromAVLError as e:
         assert e.message == "CCA name is invalid."
-
-    try:
-        response = parts.update_parts_from_AVL(
-            project="Tutorial Project",
-            cca_name="Main Board",
-            matching_mode="BOTH",
-            duplication_mode=PartsListSearchDuplicationMode.ERROR,
-            avl_part_num=AVLPartNum.ASSIGN_INTERNAL_PART_NUM,
-            avl_description=AVLDescription.ASSIGN_APPROVED_DESCRIPTION,
-        )
-    except Exception as e:
-        # The matching_mode should not be a string
-        assert type(e) == ValueError
-
-    try:
-        response = parts.update_parts_from_AVL(
-            project="Tutorial Project",
-            cca_name="Main Board",
-            matching_mode=PartsListSearchMatchingMode.BOTH,
-            duplication_mode="ERROR",
-            avl_part_num=AVLPartNum.ASSIGN_INTERNAL_PART_NUM,
-            avl_description=AVLDescription.ASSIGN_APPROVED_DESCRIPTION,
-        )
-    except Exception as e:
-        # The duplication should not be a string
-        assert type(e) == ValueError
-
-    try:
-        response = parts.update_parts_from_AVL(
-            project="Tutorial Project",
-            cca_name="Main Board",
-            matching_mode=PartsListSearchMatchingMode.BOTH,
-            duplication_mode=PartsListSearchDuplicationMode.ERROR,
-            avl_part_num="AssignInternalPartNum",
-            avl_description=AVLDescription.ASSIGN_APPROVED_DESCRIPTION,
-        )
-    except Exception as e:
-        # The avl_part_num should not be a string
-        assert type(e) == ValueError
-
-    try:
-        response = parts.update_parts_from_AVL(
-            project="Tutorial Project",
-            cca_name="Main Board",
-            matching_mode=PartsListSearchMatchingMode.BOTH,
-            duplication_mode=PartsListSearchDuplicationMode.ERROR,
-            avl_part_num=AVLPartNum.ASSIGN_INTERNAL_PART_NUM,
-            avl_description="AssignApprovedDescription",
-        )
-    except Exception as e:
-        # The avl_description should not be a string
-        assert type(e) == ValueError
 
     if parts._is_connection_up():
         try:

--- a/tests/test_project.py
+++ b/tests/test_project.py
@@ -605,15 +605,9 @@ def helper_test_list_thermal_maps(project):
 
     expected_cca_name = "Main Board"
     expected_file_names = [
-        "Thermal Map.xlsx",
-        "Thermal Map.tmap",
-        "Thermal Image.jpg",
         "Thermal Map.csv",
     ]
     expected_file_types = [
-        "Thermal Map (Excel)",
-        "Icepak Thermal Map (TMAP)",
-        "Thermal Map (Image)",
         "Thermal Map (CSV)",
     ]
 


### PR DESCRIPTION
Update parts list from AVL: fix unit tests, include classes for enums in API docs.
List thermal maps: fix unit test failure that happens when connected to Sherlock.

Checklist:
- [x] Run unit tests and make sure they all pass
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [na] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [x] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [x] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [x] Check that test code coverage is at least 80% when Sherlock is running and can be connected to using gRPC
