### PR TITLE
fix: allow newer protobuf versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,13 +27,13 @@ dependencies = [
     "ansys-api-sherlock==0.1.31",
     "grpcio>=1.17",
     "importlib-metadata>=4.0,<5; python_version<='3.8'",
-    "protobuf~=3.20",
+    "protobuf>=3.20",
 ]
 
 [project.optional-dependencies]
 tests = [
     "grpcio==1.66.1",
-    "protobuf==3.20.3",
+    "protobuf==5.28.0",
     "pytest==8.3.2",
     "pytest-cov==5.0.0",
 ]


### PR DESCRIPTION
@ansnfernand - would it be possible to do a new patch release (0.7.1) once this PR is merged? Even though you made the protobuf version more flexible in the API package, it is also required to make it more flexible on this repo.

Checklist:
- [] Run unit tests and make sure they all pass
- [] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [] Generate documentation
- [] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [] Check that test code coverage is at least 80% when Sherlock is running and can be connected to using gRPC
