### PR TITLE
Get part validation analysis properties

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ansys-api-sherlock==0.1.32",
+    "ansys-api-sherlock==0.1.33",
     "grpcio>=1.17",
     "importlib-metadata>=4.0,<5; python_version<='3.8'",
     "protobuf>=3.20",

--- a/src/ansys/sherlock/core/errors.py
+++ b/src/ansys/sherlock/core/errors.py
@@ -1234,3 +1234,15 @@ class SherlockCopyModelingRegionError(Exception):
 
         assert self.error_array is None
         return [f"Copy modeling region error: {self.message}"]
+
+
+class SherlockGetPartsListValidationAnalysisPropsError(Exception):
+    """Contains the error raised when getting parts list validation properties."""
+
+    def __init__(self, message):
+        """Initialize error message."""
+        self.message = message
+
+    def __str__(self):
+        """Format error message."""
+        return f"Get parts list validation analysis properties error: {self.message}"

--- a/src/ansys/sherlock/core/parts.py
+++ b/src/ansys/sherlock/core/parts.py
@@ -718,7 +718,7 @@ class Parts(GrpcStub):
                 - value : int
                     Status code of the response. 0 for success.
                 - message : str
-                    indicates general errors that occurred while attempting to update parts
+                    Indicates general errors that occurred while attempting to update parts
             - numPartsUpdated : int
                 Number of parts updated
             - updateErrors : list<str>

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -11,6 +11,7 @@ import pytest
 
 from ansys.sherlock.core.analysis import Analysis
 from ansys.sherlock.core.errors import (
+    SherlockGetPartsListValidationAnalysisPropsError,
     SherlockRunAnalysisError,
     SherlockRunStrainMapAnalysisError,
     SherlockUpdateHarmonicVibePropsError,
@@ -58,6 +59,7 @@ def test_all():
     helper_test_update_pcb_modeling_props(analysis)
     helper_test_update_part_modeling_props(analysis)
     helper_test_update_parts_list_validation_props(analysis)
+    helper_test_get_parts_list_validation_analysis_props(analysis)
 
 
 def helper_test_run_analysis(analysis):
@@ -1780,6 +1782,45 @@ def helper_test_update_parts_list_validation_props(analysis):
         assert result == 0
     except SherlockUpdatePartListValidationAnalysisPropsError as e:
         pytest.fail(str(e))
+
+
+def helper_test_get_parts_list_validation_analysis_props(analysis):
+    try:
+        analysis.get_parts_list_validation_analysis_props("", "Main Board")
+        pytest.fail("No exception raised when using an invalid parameter")
+    except SherlockGetPartsListValidationAnalysisPropsError as e:
+        assert (
+            str(e)
+            == "Get parts list validation analysis properties error: Project name is invalid."
+        )
+
+    if analysis._is_connection_up():
+        try:
+            analysis.get_parts_list_validation_analysis_props(
+                "Tutorial Project",
+                "Invalid CCA name",
+            )
+            pytest.fail("No exception raised when using an invalid parameter")
+        except Exception as e:
+            assert type(e) == SherlockGetPartsListValidationAnalysisPropsError
+
+        try:
+            response = analysis.get_parts_list_validation_analysis_props(
+                "Tutorial Project",
+                "Main Board",
+            )
+            assert response is not None
+            assert response.partLibrary is not None
+            assert response.processUseAVL is not None
+            assert response.processUseWizard is not None
+            assert response.processCheckConfirmedProperties is not None
+            assert response.processCheckPartNumbers is not None
+            assert response.matching is not None
+            assert response.avlRequireInternalPartNumber is not None
+            assert response.avlRequireApprovedDescription is not None
+            assert response.avlRequireApprovedManufacturer is not None
+        except SherlockGetPartsListValidationAnalysisPropsError as e:
+            pytest.fail(str(e))
 
 
 if __name__ == "__main__":

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -873,6 +873,7 @@ def helper_test_add_modeling_region(layer):
         try:
             valid_region = copy.deepcopy(modeling_region_example)
             valid_region[0]["cca_name"] = "Main Board"
+            valid_region[0]["region_id"] = f"Region{uuid.uuid4()}"
             result = layer.add_modeling_region("Tutorial Project", valid_region)
             assert result == 0
         except SherlockAddModelingRegionError as e:
@@ -881,6 +882,7 @@ def helper_test_add_modeling_region(layer):
 
 
 def helper_test_update_modeling_region(layer, region_id):
+    updated_region_id = f"UpdatedRegion{uuid.uuid4()}"
     modeling_region_example = [
         {
             "cca_name": "Card",
@@ -901,9 +903,11 @@ def helper_test_update_modeling_region(layer, region_id):
                 "trace_mesh_size": 0.3,
                 "trace_mesh_size_units": "mm",
             },
-            "region_id_replacement": "NewRegion001",
+            "region_id_replacement": updated_region_id,
         }
     ]
+
+    region_id = updated_region_id
 
     # Invalid project name
     try:
@@ -1030,8 +1034,9 @@ def helper_test_update_modeling_region(layer, region_id):
             valid_region[0]["shape"] = RectangularShape(
                 length=10.0, width=5.0, center_x=0.0, center_y=0.0, rotation=45.0
             )
-            valid_region[0]["region_id"] = "NewRegion001"
-            valid_region[0]["region_id_replacement"] = "NewRegion002"
+            valid_region[0]["region_id"] = region_id
+            region_id = f"UpdatedRegion{uuid.uuid4()}"
+            valid_region[0]["region_id_replacement"] = region_id
             result = layer.update_modeling_region("Tutorial Project", valid_region)
             assert result == 0
         except SherlockUpdateModelingRegionError as e:
@@ -1044,22 +1049,23 @@ def helper_test_update_modeling_region(layer, region_id):
             valid_region[0]["shape"] = SlotShape(
                 length=10.0, width=5.0, node_count=6, center_x=0.0, center_y=0.0, rotation=45.0
             )
-            valid_region[0]["region_id"] = "NewRegion002"
-            valid_region[0]["region_id_replacement"] = "NewRegion003"
+            valid_region[0]["region_id"] = region_id
+            region_id = f"UpdatedRegion{uuid.uuid4()}"
+            valid_region[0]["region_id_replacement"] = region_id
             result = layer.update_modeling_region("Tutorial Project", valid_region)
             assert result == 0
         except SherlockUpdateModelingRegionError as e:
             pytest.fail(str(e))
 
         # Test for CircularShape
-        region_id = "NewRegion004"
         try:
             valid_region = copy.deepcopy(modeling_region_example)
             valid_region[0]["cca_name"] = "Main Board"
             valid_region[0]["shape"] = CircularShape(
                 diameter=10.0, node_count=8, center_x=0.0, center_y=0.0, rotation=0.0
             )
-            valid_region[0]["region_id"] = "NewRegion003"
+            valid_region[0]["region_id"] = region_id
+            region_id = f"UpdatedRegion{uuid.uuid4()}"
             valid_region[0]["region_id_replacement"] = region_id
             result = layer.update_modeling_region("Tutorial Project", valid_region)
             assert result == 0
@@ -1069,11 +1075,12 @@ def helper_test_update_modeling_region(layer, region_id):
 
 
 def helper_test_copy_modeling_region(layer, region_id):
+    region_id_copy = f"RegionCopy{uuid.uuid4()}"
     copy_region_example = [
         {
             "cca_name": "Card",
             "region_id": region_id,
-            "region_id_copy": "RegionCopy001",
+            "region_id_copy": region_id_copy,
             "center_x": 10.0,
             "center_y": 20.0,
         }
@@ -1150,7 +1157,6 @@ def helper_test_copy_modeling_region(layer, region_id):
         try:
             valid_region = copy.deepcopy(copy_region_example)
             valid_region[0]["cca_name"] = "Main Board"
-            valid_region[0]["region_id"] = region_id
             result = layer.copy_modeling_region("Tutorial Project", valid_region)
             assert result == 0
         except SherlockCopyModelingRegionError as e:

--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -49,7 +49,7 @@ def test_all():
     helper_test_export_all_test_fixtures(layer)
     helper_test_export_all_test_points(layer)
     region_id = helper_test_add_modeling_region(layer)
-    helper_test_update_modeling_region(layer, region_id)
+    region_id = helper_test_update_modeling_region(layer, region_id)
     helper_test_copy_modeling_region(layer, region_id)
 
 
@@ -658,7 +658,7 @@ def helper_test_export_all_test_fixtures(layer):
 
         try:
             result = layer.export_all_test_fixtures(
-                "Tutorial Project",
+                "Test Point Test Project",
                 "Main Board",
                 test_fixtures_file,
             )
@@ -709,18 +709,6 @@ def helper_test_export_all_mount_points(layer):
         mount_points_file = os.path.join(temp_dir, "mount_points.csv")
 
         try:
-            result = layer.export_all_mount_points(
-                "Tutorial Project",
-                "Main Board",
-                mount_points_file,
-            )
-
-            assert os.path.exists(mount_points_file)
-            assert result == 0
-        except Exception as e:
-            pytest.fail(e.message)
-
-        try:
             layer.export_all_mount_points(
                 "Tutorial Project",
                 "Invalid CCA",
@@ -729,6 +717,18 @@ def helper_test_export_all_mount_points(layer):
             pytest.fail("No exception raised when using an invalid parameter")
         except Exception as e:
             assert type(e) == SherlockExportAllMountPoints
+
+        try:
+            result = layer.export_all_mount_points(
+                "Test Point Test Project",
+                "Main Board",
+                mount_points_file,
+            )
+
+            assert os.path.exists(mount_points_file)
+            assert result == 0
+        except SherlockExportAllMountPoints as e:
+            pytest.fail(e.message)
 
 
 def helper_test_add_modeling_region(layer):
@@ -1030,6 +1030,7 @@ def helper_test_update_modeling_region(layer, region_id):
             valid_region[0]["shape"] = RectangularShape(
                 length=10.0, width=5.0, center_x=0.0, center_y=0.0, rotation=45.0
             )
+            valid_region[0]["region_id"] = "NewRegion001"
             valid_region[0]["region_id_replacement"] = "NewRegion002"
             result = layer.update_modeling_region("Tutorial Project", valid_region)
             assert result == 0
@@ -1041,8 +1042,9 @@ def helper_test_update_modeling_region(layer, region_id):
             valid_region = copy.deepcopy(modeling_region_example)
             valid_region[0]["cca_name"] = "Main Board"
             valid_region[0]["shape"] = SlotShape(
-                length=10.0, width=5.0, node_count=4, center_x=0.0, center_y=0.0, rotation=45.0
+                length=10.0, width=5.0, node_count=6, center_x=0.0, center_y=0.0, rotation=45.0
             )
+            valid_region[0]["region_id"] = "NewRegion002"
             valid_region[0]["region_id_replacement"] = "NewRegion003"
             result = layer.update_modeling_region("Tutorial Project", valid_region)
             assert result == 0
@@ -1050,15 +1052,18 @@ def helper_test_update_modeling_region(layer, region_id):
             pytest.fail(str(e))
 
         # Test for CircularShape
+        region_id = "NewRegion004"
         try:
             valid_region = copy.deepcopy(modeling_region_example)
             valid_region[0]["cca_name"] = "Main Board"
             valid_region[0]["shape"] = CircularShape(
                 diameter=10.0, node_count=8, center_x=0.0, center_y=0.0, rotation=0.0
             )
-            valid_region[0]["region_id_replacement"] = "NewRegion004"
+            valid_region[0]["region_id"] = "NewRegion003"
+            valid_region[0]["region_id_replacement"] = region_id
             result = layer.update_modeling_region("Tutorial Project", valid_region)
             assert result == 0
+            return region_id
         except SherlockUpdateModelingRegionError as e:
             pytest.fail(str(e))
 
@@ -1145,6 +1150,7 @@ def helper_test_copy_modeling_region(layer, region_id):
         try:
             valid_region = copy.deepcopy(copy_region_example)
             valid_region[0]["cca_name"] = "Main Board"
+            valid_region[0]["region_id"] = region_id
             result = layer.copy_modeling_region("Tutorial Project", valid_region)
             assert result == 0
         except SherlockCopyModelingRegionError as e:


### PR DESCRIPTION
Also fixed layer unit tests that fail when connected to Sherlock.

Checklist:
- [x] Run unit tests and make sure they all pass
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [x] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [x] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [x] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [x] Check that test code coverage is at least 80% when Sherlock is running and can be connected to using gRPC
