### PR TITLE
Bug fix: single_project_path argument

### DIFF
--- a/src/ansys/sherlock/core/launcher.py
+++ b/src/ansys/sherlock/core/launcher.py
@@ -77,7 +77,8 @@ def launch_sherlock(
         args = [_get_sherlock_exe_path()]
         args.append("-grpcPort=" + str(port))
         if single_project_path != "":
-            args.append(f'-singleProject "{single_project_path}"')
+            args.append("-singleProject")
+            args.append(single_project_path)
         if sherlock_cmd_args != "":
             args.append(f"{shlex.split(sherlock_cmd_args)}")
         print(args)


### PR DESCRIPTION
Checklist:
- [x] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [x] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [x] Check that test code coverage is at least 80% when Sherlock is running
