### PR TITLE
Remove sleep() calls from unit tests since they are no longer needed

### DIFF
--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,5 +1,4 @@
-# © 2023 ANSYS, Inc. All rights reserved
-import time
+# Copyright (C) 2023-2024 ANSYS, Inc. and/or its affiliates.
 
 try:
     import SherlockAnalysisService_pb2
@@ -41,7 +40,6 @@ def test_all():
     channel = grpc.insecure_channel(channel_param)
     analysis = Analysis(channel)
     helper_test_run_analysis(analysis)
-    time.sleep(1)
     helper_test_run_strain_map_analysis(analysis)
     helper_test_get_harmonic_vibe_input_fields(analysis)
     helper_test_get_ict_analysis_input_fields(analysis)

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -1,8 +1,7 @@
-# © 2023 ANSYS, Inc. All rights reserved
+# Copyright (C) 2023-2024 ANSYS, Inc. and/or its affiliates.
 
 import os
 import platform
-import time
 
 import grpc
 import pytest
@@ -35,9 +34,7 @@ def test_all():
     parts = Parts(channel)
 
     helper_test_update_parts_list(parts)
-    time.sleep(1)
     helper_test_update_parts_list_properties(parts)
-    time.sleep(1)
     helper_test_update_parts_from_AVL(parts)
     helper_test_update_parts_locations(parts)
     helper_test_update_parts_locations_by_file(parts)
@@ -61,8 +58,6 @@ def helper_test_update_parts_list(parts):
                 PartsListSearchDuplicationMode.ERROR,
             )
             assert result == 0
-            # wait for Sherlock to finish updating so subsequent tests don't fail
-            time.sleep(1)
         except Exception as e:
             pytest.fail(e.message)
 
@@ -534,9 +529,6 @@ def helper_test_export_parts_list(parts):
                 parts_list_file,
             )
             assert os.path.exists(parts_list_file)
-            # may need to wait for a bit because the response may be returned
-            # before Sherlock finishes writing the file
-            time.sleep(0.5)
             assert result == 0
         except Exception as e:
             pytest.fail(e.message)

--- a/tests/test_stackup.py
+++ b/tests/test_stackup.py
@@ -1,6 +1,4 @@
-# © 2023 ANSYS, Inc. All rights reserved
-
-import time
+# Copyright (C) 2023-2024 ANSYS, Inc. and/or its affiliates.
 
 import grpc
 import pytest
@@ -167,8 +165,6 @@ def helper_test_gen_stackup(stackup):
                 "mil",
             )
             assert result == 0
-            # wait for the process to finish to allow tests that modify a layer to succeed
-            time.sleep(2)
         except SherlockGenStackupError as e:
             pytest.fail(str(e))
 
@@ -275,7 +271,6 @@ def helper_test_update_conductor_layer(stackup):
                 resin_material="Generic FR-4 Generic FR-4",
             )
             assert result == 0
-            time.sleep(1)
         except SherlockUpdateConductorLayerError as e:
             pytest.fail(str(e))
 
@@ -465,7 +460,6 @@ def helper_test_update_laminate_layer(stackup):
                 "0.0",
             )
             assert result == 0
-            time.sleep(1)
         except SherlockUpdateLaminateLayerError as e:
             pytest.fail(str(e))
 


### PR DESCRIPTION
Checklist:
- [] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [] Generate documentation
- [] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [] Check that test code coverage is at least 80% when Sherlock is running
