### PR TITLE
MAINT: Add support for Python 3.13

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.10'
+  MAIN_PYTHON_VERSION: '3.13'
   PACKAGE_NAME: 'ansys-sherlock-core'
   PACKAGE_NAMESPACE: 'ansys.sherlock.core'
   DOCUMENTATION_CNAME: 'sherlock.docs.pyansys.com'
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:
@@ -67,7 +67,7 @@ jobs:
     runs-on: [ self-hosted, pysherlock ]
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
 
     steps:
       - uses: actions/checkout@v4

--- a/doc/changelog.d/481.dependencies.md
+++ b/doc/changelog.d/481.dependencies.md
@@ -1,0 +1,1 @@
+Add support for Python 3.13. Remove some references to Python 3.8 and 3.9

--- a/doc/changelog.d/481.dependencies.md
+++ b/doc/changelog.d/481.dependencies.md
@@ -1,1 +1,0 @@
-Add support for Python 3.13. Remove some references to Python 3.8 and 3.9

--- a/doc/changelog.d/481.documentation.md
+++ b/doc/changelog.d/481.documentation.md
@@ -1,0 +1,1 @@
+MAINT: Add support for Python 3.13. Remove some references to Python 3.8 and 3.9

--- a/doc/changelog.d/481.documentation.md
+++ b/doc/changelog.d/481.documentation.md
@@ -1,1 +1,1 @@
-MAINT: Add support for Python 3.13. Remove some references to Python 3.8 and 3.9
+MAINT: Add support for Python 3.13

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 
 dependencies = [

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 description = Default tox environments list
 envlist =
-    style,{py38,py39,py310,py311}{,-coverage},doc
+    style,{py310,py311,py312,py313}{,-coverage},doc
 skip_missing_interpreters = true
 isolated_build = true
 isolated_build_env = build
@@ -9,10 +9,10 @@ isolated_build_env = build
 [testenv]
 description = Checks for project unit tests and coverage (if desired)
 basepython =
-    py38: python3.8
-    py39: python3.9
     py310: python3.10
     py311: python3.11
+    py311: python3.12
+    py311: python3.13
     py: python3
     {style,reformat,doc}: python3
 setenv =


### PR DESCRIPTION
## Description
Add support for Python 3.13. Remove some references to Python 3.8 and 3.9

## Issue linked
#460

## Checklist:
- [] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [] Generate documentation
- [] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [] Check that test code coverage is at least 80% when Sherlock is running
- [] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
