### PR TITLE
feat: New API update_semiconductor_wearout_props()

### DIFF
--- a/doc/changelog.d/488.added.md
+++ b/doc/changelog.d/488.added.md
@@ -1,0 +1,1 @@
+feat: New API update_semiconductor_wearout_props()

--- a/src/ansys/sherlock/core/analysis.py
+++ b/src/ansys/sherlock/core/analysis.py
@@ -14,6 +14,7 @@ from ansys.sherlock.core.types.analysis_types import (
     UpdatePcbModelingPropsRequestAnalysisType,
     UpdatePcbModelingPropsRequestPcbMaterialModel,
     UpdatePcbModelingPropsRequestPcbModelType,
+    UpdateSemiconductorWearoutAnalysisPropsRequest,
 )
 
 try:
@@ -2232,5 +2233,73 @@ class Analysis(GrpcStub):
 
         responses = []
         for return_code in self.stub.updateComponentFailureMechanismProps(update_request):
+            responses.append(return_code)
+        return responses
+
+    @require_version(252)
+    def update_semiconductor_wearout_props(
+        self,
+        request: UpdateSemiconductorWearoutAnalysisPropsRequest,
+    ) -> list[SherlockCommonService_pb2.ReturnCode]:
+        r"""Update properties for one or more Semiconductor Wearout Analysis.
+
+        Parameters
+        ----------
+        request: UpdateSemiconductorWearoutAnalysisPropsRequest
+            Contains all the information needed to update the properties for one or more
+            semiconductor wearout analyses per project.
+
+        Returns
+        -------
+        list[SherlockCommonService_pb2.ReturnCode]
+            Return codes for each request.
+
+        Examples
+        --------
+        >>> from ansys.sherlock.core.launcher import launch_sherlock
+        >>> from ansys.sherlock.core.types.analysis_types import (
+            SemiconductorWearoutAnalysis,
+            UpdateSemiconductorWearoutAnalysisPropsRequest,
+        )
+        >>> sherlock = launch_sherlock()
+        >>> sherlock.project.import_project_zip_archive(
+            project="Assembly Tutorial",
+            category="category",
+            archive_file=\
+                "C:\\Program Files\\ANSYS Inc\\v252\\sherlock\\tutorial\\Assembly Tutorial.zip",
+        )
+        >>> update_request1 = SemiconductorWearoutAnalysis(
+            cca_name="Main Board",
+            max_feature_size=1.5,
+            max_feature_size_units="mm",
+            part_temp_rise=10.0,
+            part_temp_rise_units="C",
+            part_temp_rise_min_enabled=True,
+            part_validation_enabled=False,
+        )
+        >>> update_request2 = SemiconductorWearoutAnalysis(
+            cca_name="Memory Card 1",
+            max_feature_size=2.0,
+            max_feature_size_units="mm",
+            part_temp_rise=15.0,
+            part_temp_rise_units="C",
+            part_temp_rise_min_enabled=False,
+            part_validation_enabled=True,
+        )
+        >>> request = UpdateSemiconductorWearoutAnalysisPropsRequest(
+            project="Test",
+            semiconductor_wearout_analysis_properties=[
+                update_request1,
+                update_request2
+            ]
+        )
+        >>> return_codes = sherlock.analysis.update_semiconductor_wearout_props(request)
+        >>> for return_code in return_codes:
+                print(f"Return code: value={return_code.value}, message={return_code.message}")
+        """
+        update_request = request._convert_to_grpc()
+
+        responses = []
+        for return_code in self.stub.updateSemiconductorWearoutAnalysisProps(update_request):
             responses.append(return_code)
         return responses

--- a/src/ansys/sherlock/core/analysis.py
+++ b/src/ansys/sherlock/core/analysis.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023-2025 ANSYS, Inc. and/or its affiliates.
 
 """Module containing all analysis capabilities."""
 from typing import Optional

--- a/src/ansys/sherlock/core/types/analysis_types.py
+++ b/src/ansys/sherlock/core/types/analysis_types.py
@@ -1,4 +1,4 @@
-# © 2023-2024 ANSYS, Inc. All rights reserved.
+# © 2023-2025 ANSYS, Inc. All rights reserved.
 
 """Module containing types for the Analysis Service."""
 

--- a/src/ansys/sherlock/core/types/analysis_types.py
+++ b/src/ansys/sherlock/core/types/analysis_types.py
@@ -179,3 +179,72 @@ class UpdateComponentFailureMechanismPropsRequest(BaseModel):
         for properties in self.component_failure_mechanism_properties_per_cca:
             request.componentFailureMechanismProperties.append(properties._convert_to_grpc())
         return request
+
+
+class SemiconductorWearoutAnalysis(BaseModel):
+    """Contains the properties of a semiconductor wearout analysis update request."""
+
+    cca_name: str
+    """Name of the CCA."""
+    max_feature_size: float
+    """Maximum feature size."""
+    max_feature_size_units: str
+    """Units of the maximum feature size."""
+    part_temp_rise: float
+    """Part temperature rise."""
+    part_temp_rise_units: str
+    """Units of the part temperature rise."""
+    part_temp_rise_min_enabled: bool
+    """Whether part temperature rise value is applied to the minimum temperature defined in the
+    thermal cycle."""
+    part_validation_enabled: bool
+    """Whether part validation should be performed."""
+
+    def _convert_to_grpc(
+        self,
+    ) -> (
+        analysis_service.UpdateSemiconductorWearoutAnalysisPropsRequest.SemiconductorWearoutAnalysis
+    ):
+
+        request_class = analysis_service.UpdateSemiconductorWearoutAnalysisPropsRequest
+        semiconductor_wearout_analysis = request_class.SemiconductorWearoutAnalysis
+        grpc_data = semiconductor_wearout_analysis()
+
+        grpc_data.ccaName = self.cca_name
+        grpc_data.maxFeatureSize = self.max_feature_size
+        grpc_data.maxFeatureSizeUnits = self.max_feature_size_units
+        grpc_data.partTempRise = self.part_temp_rise
+        grpc_data.partTempRiseUnits = self.part_temp_rise_units
+        grpc_data.partTempRiseMinEnabled = self.part_temp_rise_min_enabled
+        grpc_data.partValidationEnabled = self.part_validation_enabled
+        return grpc_data
+
+    @field_validator("cca_name", "max_feature_size_units", "part_temp_rise_units")
+    @classmethod
+    def str_validation(cls, value: str, info: ValidationInfo):
+        """Validate string fields listed."""
+        return basic_str_validator(value, info.field_name)
+
+
+class UpdateSemiconductorWearoutAnalysisPropsRequest(BaseModel):
+    """Contains the properties of a semiconductor wearout analysis update per project."""
+
+    project: str
+    """Name of the Sherlock project."""
+    semiconductor_wearout_analysis_properties: list[SemiconductorWearoutAnalysis]
+    """List of semiconductor wearout analysis properties to update."""
+
+    @field_validator("project")
+    @classmethod
+    def str_validation(cls, value: str, info: ValidationInfo):
+        """Validate string fields listed."""
+        return basic_str_validator(value, info.field_name)
+
+    def _convert_to_grpc(
+        self,
+    ) -> analysis_service.UpdateSemiconductorWearoutAnalysisPropsRequest:
+        request = analysis_service.UpdateSemiconductorWearoutAnalysisPropsRequest()
+        request.project = self.project
+        for properties in self.semiconductor_wearout_analysis_properties:
+            request.semiconductorWearoutAnalysisProperties.append(properties._convert_to_grpc())
+        return request

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023-2024 ANSYS, Inc. and/or its affiliates.
+# Copyright (C) 2023-2025 ANSYS, Inc. and/or its affiliates.
 
 try:
     import SherlockAnalysisService_pb2


### PR DESCRIPTION
## Description
New API update_semiconductor_wearout_props()

## Issue linked
#484

## Checklist:
- [x] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [x] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [x] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [x] Check that test code coverage is at least 80% when Sherlock is running
- [x] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
