### PR TITLE
fix: API updatePTHFatigueProps()

### DIFF
--- a/doc/changelog.d/506.fixed.md
+++ b/doc/changelog.d/506.fixed.md
@@ -1,0 +1,1 @@
+fix: API updatePTHFatigueProps()

--- a/src/ansys/sherlock/core/types/analysis_types.py
+++ b/src/ansys/sherlock/core/types/analysis_types.py
@@ -298,7 +298,7 @@ class PTHFatiguePropsAnalysis(BaseModel):
 
         grpc_data.ccaName = self.cca_name
         if self.qualification is not None:
-            grpc_data.qualification = self.qualification.name
+            grpc_data.qualification = self.qualification.value
         if self.pth_quality_factor is not None:
             grpc_data.pthQualityFactor = self.pth_quality_factor
         if self.pth_wall_thickness is not None:


### PR DESCRIPTION
## Description
Fix this error:

G:\agent\_work\20\PySherlock\src\ansys\sherlock\core\types\analysis_types.py:301: TypeError: 'SUPPLIER' has type str, but expected one of: int

## Issue linked

## Checklist:
- [x] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [x] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [x] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [x] Check that test code coverage is at least 80% when Sherlock is running
- [x] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
