### PR TITLE
fix: PartLocation variable was renamed by mistake

### DIFF
--- a/doc/changelog.d/515.fixed.md
+++ b/doc/changelog.d/515.fixed.md
@@ -1,0 +1,1 @@
+fix: PartLocation variable was renamed by mistake

--- a/src/ansys/sherlock/core/types/parts_types.py
+++ b/src/ansys/sherlock/core/types/parts_types.py
@@ -89,7 +89,7 @@ class PartLocation:
         """board side - ``"TOP"`` or ``"BOTTOM"`` """
         self.mirrored = location.mirrored
         """mirrored - ``True`` or ``False`` """
-        self.reference_designators = location.refDes
+        self.ref_des = location.refDes
         """reference designator"""
 
 


### PR DESCRIPTION
## Description
PartLocation variable was renamed by mistake

## Issue linked
#505 

## Checklist:
- [x] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [x] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [x] Check that test code coverage is at least 80% when Sherlock is running
- [x] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
