### PR TITLE
fix: update_pad_properties - returnCode management

### DIFF
--- a/doc/changelog.d/522.fixed.md
+++ b/doc/changelog.d/522.fixed.md
@@ -1,0 +1,1 @@
+fix: update_pad_properties - returnCode management

--- a/src/ansys/sherlock/core/parts.py
+++ b/src/ansys/sherlock/core/parts.py
@@ -1130,7 +1130,10 @@ class Parts(GrpcStub):
                 print(f"Return code: value={res.returnCode.value}, message={res.returnCode.message},
                 reference_designators={res.reference_designators}")
         """
-        update_request = request._convert_to_grpc()
-        response_stream = self.stub.updatePadProperties(update_request)
 
-        return response_stream
+        if not self._is_connection_up():
+            raise SherlockNoGrpcConnectionException()
+
+        update_request = request._convert_to_grpc()
+
+        return list(self.stub.updatePadProperties(update_request))

--- a/src/ansys/sherlock/core/parts.py
+++ b/src/ansys/sherlock/core/parts.py
@@ -1130,7 +1130,6 @@ class Parts(GrpcStub):
                 print(f"Return code: value={res.returnCode.value}, message={res.returnCode.message},
                 reference_designators={res.reference_designators}")
         """
-
         if not self._is_connection_up():
             raise SherlockNoGrpcConnectionException()
 

--- a/src/ansys/sherlock/core/types/parts_types.py
+++ b/src/ansys/sherlock/core/types/parts_types.py
@@ -134,10 +134,8 @@ class UpdatePadPropertiesRequest(BaseModel):
         return basic_str_validator(value, info.field_name)
 
     def _convert_to_grpc(self) -> parts_service.UpdatePadPropertiesRequest:
-        request = parts_service.UpdatePadPropertiesRequest()
-        request.project = self.project
-        request.ccaName = self.cca_name
-        request.refDes.extend(
-            self.reference_designators if self.reference_designators is not None else []
+        return parts_service.UpdatePadPropertiesRequest(
+            project=self.project,
+            ccaName=self.cca_name,
+            refDes=self.reference_designators,
         )
-        return request

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -972,8 +972,8 @@ def helper_test_update_pad_properties(parts: Parts):
         if parts._is_connection_up():
             responses = parts.update_pad_properties(request)
 
-            assert responses.returnCode.value == -1
-            assert responses.returnCode.message == f"Cannot find project: {request.project}"
+            assert responses[0].returnCode.value == -1
+            assert responses[0].returnCode.message == f"Cannot find project: {request.project}"
 
             request.project = "Tutorial Project"
             responses = parts.update_pad_properties(request)

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -972,6 +972,7 @@ def helper_test_update_pad_properties(parts: Parts):
         if parts._is_connection_up():
             responses = parts.update_pad_properties(request)
 
+            assert len(responses) == 1, "Expected exactly one response in the list"
             assert responses[0].returnCode.value == -1
             assert responses[0].returnCode.message == f"Cannot find project: {request.project}"
 
@@ -979,6 +980,9 @@ def helper_test_update_pad_properties(parts: Parts):
             responses = parts.update_pad_properties(request)
             responses = list(responses)
 
+            assert len(responses) == len(
+                request.reference_designators
+            ), "Mismatch between responses and reference designators"
             for res in responses:
                 assert res.returnCode.value == 0
                 assert res.refDes in request.reference_designators


### PR DESCRIPTION
## Description
#385 

## Issue linked
#385

## Checklist:
- [x] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [x] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [x] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [x] Check that test code coverage is at least 80% when Sherlock is running
- [x] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
