### PR TITLE
maint: set sphinx-design as documentation requirement

### DIFF
--- a/doc/changelog.d/535.documentation.md
+++ b/doc/changelog.d/535.documentation.md
@@ -1,0 +1,1 @@
+maint: set sphinx-design as documentation requirement

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -68,7 +68,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
-    "sphinx_design",
+    "sphinx-design",
 ]
 
 autodoc_default_flags = ["members"]

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -68,7 +68,7 @@ extensions = [
     "sphinx.ext.napoleon",
     "sphinx.ext.autosummary",
     "sphinx.ext.intersphinx",
-    "sphinx-design",
+    "sphinx_design",
 ]
 
 autodoc_default_flags = ["members"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ doc = [
     "numpydoc==1.8.0",
     "Sphinx==8.2.3", # BLOCKED BY sphinx-design - Cannot upgrade to Sphinx 7 for now
     "sphinx-copybutton==0.5.2",
-    "sphinx_design==0.6.1",
+    "sphinx-design==0.6.1",
     "sphinx-gallery==0.19.0",
 ]
 


### PR DESCRIPTION
## Description
Modified conf.py and pyproject.toml: in the extensions section, renamed "sphinx_design" to "sphinx-design"

## Issue linked


## Checklist:
- [] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [] Generate documentation
- [] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [] Check that test code coverage is at least 80% when Sherlock is running
- [] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
