### PR TITLE
docs: fix documentation warnings

### DIFF
--- a/doc/changelog.d/581.documentation.md
+++ b/doc/changelog.d/581.documentation.md
@@ -1,1 +1,0 @@
-docs: fix documentation warnings

--- a/doc/changelog.d/581.documentation.md
+++ b/doc/changelog.d/581.documentation.md
@@ -1,0 +1,1 @@
+docs: fix documentation warnings

--- a/doc/changelog.d/581.miscellaneous.md
+++ b/doc/changelog.d/581.miscellaneous.md
@@ -1,0 +1,1 @@
+Docs: fix documentation warnings

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -30,7 +30,7 @@ The following table shows the version of PySherlock to use for each release of S
 +------------+----------+
 
 To install a specific version of PySherlock, use the following command, where the <version> is one
-of the values in the table above:
+of the values in the table preceding:
 
 .. code::
 

--- a/src/ansys/sherlock/core/types/common_types.py
+++ b/src/ansys/sherlock/core/types/common_types.py
@@ -119,6 +119,6 @@ class Measurement:
     def __init__(self, value: float, unit: str):
         """Initialize the measurement properties."""
         self.value = value
-        """float: measurement value"""
+        """float: Measurement value"""
         self.unit = unit
-        """str: measurement units"""
+        """str: Measurement units"""

--- a/src/ansys/sherlock/core/types/layer_types.py
+++ b/src/ansys/sherlock/core/types/layer_types.py
@@ -15,9 +15,9 @@ class PolygonalShape(BaseModel):
     """Contains the properties for a polygonal shape."""
 
     points: list[tuple[float, float]]
-    """points (length two tuples of the form (x, y)) : list[tuple[float, float]]"""
+    """Points (length two tuples of the form (x, y)) : list[tuple[float, float]]"""
     rotation: float
-    """rotation (in degrees) : float"""
+    """Rotation (in degrees) : float"""
 
     def _convert_to_grpc(self) -> SherlockLayerService_pb2.PolygonalShape:
         grpc_polygonal_shape = SherlockLayerService_pb2.PolygonalShape()
@@ -33,15 +33,15 @@ class RectangularShape(BaseModel):
     """Contains the properties for a rectangular shape."""
 
     length: float
-    """length : float"""
+    """Length : float"""
     width: float
-    """width : float"""
+    """Width : float"""
     center_x: float
-    """x coordinate of center : float"""
+    """X coordinate of center : float"""
     center_y: float
-    """y coordinate of center : float"""
+    """Y coordinate of center : float"""
     rotation: float
-    """rotation (in degrees) : float"""
+    """Rotation (in degrees) : float"""
 
     def _convert_to_grpc(self) -> SherlockLayerService_pb2.RectangularShape:
         grpc_rectangular_shape = SherlockLayerService_pb2.RectangularShape()
@@ -57,17 +57,17 @@ class SlotShape(BaseModel):
     """Contains the properties for a slot shape."""
 
     length: float
-    """length : float"""
+    """Length : float"""
     width: float
-    """width : float"""
+    """Width : float"""
     node_count: int
-    """node count : int"""
+    """Node count : int"""
     center_x: float
-    """x coordinate of center : float"""
+    """X coordinate of center : float"""
     center_y: float
-    """y coordinate of center : float"""
+    """Y coordinate of center : float"""
     rotation: float
-    """rotation (in degrees) : float"""
+    """Rotation (in degrees) : float"""
 
     def _convert_to_grpc(self) -> SherlockLayerService_pb2.SlotShape:
         grpc_slot_shape = SherlockLayerService_pb2.SlotShape()
@@ -86,15 +86,15 @@ class CircularShape(BaseModel):
     """Contains the properties for a circular shape."""
 
     diameter: float
-    """diameter : float"""
+    """Diameter : float"""
     node_count: int
-    """node count : int"""
+    """Node count : int"""
     center_x: float
-    """x coordinate of center : float"""
+    """X coordinate of center : float"""
     center_y: float
-    """y coordinate of center : float"""
+    """Y coordinate of center : float"""
     rotation: float
-    """rotation (in degrees) : float"""
+    """Rotation (in degrees) : float"""
 
     def _convert_to_grpc(self) -> SherlockLayerService_pb2.CircularShape:
         grpc_circular_shape = SherlockLayerService_pb2.CircularShape()
@@ -171,7 +171,7 @@ class PottingRegionUpdateData(BaseModel):
     """Contains the properties of a potting region update request."""
 
     potting_region_id_to_update: str
-    """Id of the potting region to update."""
+    """ID of the potting region to update."""
     potting_region: PottingRegion
     """Potting region data used to update the potting region."""
 
@@ -224,9 +224,9 @@ class PottingRegionCopyData(BaseModel):
     cca_name: str
     """Name of the cca."""
     potting_id: str
-    """Id to assign to the new potting region."""
+    """ID to assign to the new potting region."""
     copy_potting_id: str
-    """Id of the potting region to copy."""
+    """ID of the potting region to copy."""
     center_x: float
     """X coordinate for the center of the new potting region."""
     center_y: float

--- a/src/ansys/sherlock/core/types/parts_types.py
+++ b/src/ansys/sherlock/core/types/parts_types.py
@@ -77,19 +77,19 @@ class PartLocation:
     def __init__(self, location):
         """Initialize members from the location."""
         self.x = location.x
-        """x coordinate"""
+        """X coordinate"""
         self.y = location.y
-        """y coordinate"""
+        """Y coordinate"""
         self.rotation = location.rotation
-        """rotation (in degrees)"""
+        """Rotation (in degrees)"""
         self.location_units = location.locationUnits
-        """units for location coordinates"""
+        """Units for location coordinates"""
         self.board_side = location.boardSide
-        """board side - ``"TOP"`` or ``"BOTTOM"`` """
+        """Board side - ``"TOP"`` or ``"BOTTOM"`` """
         self.mirrored = location.mirrored
-        """mirrored - ``True`` or ``False`` """
+        """Mirrored - ``True`` or ``False`` """
         self.ref_des = location.refDes
-        """reference designator"""
+        """Reference designator"""
 
 
 class GetPartsListPropertiesRequest(BaseModel):


### PR DESCRIPTION
## Description
Fix documentation warnings- change word in installation instructions, capitalize first word of doc comments for type class members.

## Issue linked
**Please mention the issue number or describe the problem this pull request addresses.**

## Checklist:
- [] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [x] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [] Check that test code coverage is at least 80% when Sherlock is running
- [x] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
