### PR TITLE
Use pytest.approx() for floating point values

### DIFF
--- a/tests/test_layer.py
+++ b/tests/test_layer.py
@@ -1581,8 +1581,8 @@ def helper_test_get_test_point_props(layer):
         assert responses[0].testPointProperties.ID == "TP1"
         assert responses[0].testPointProperties.side == "TOP"
         assert responses[0].testPointProperties.units == "mm"
-        assert responses[0].testPointProperties.centerX == 53.09614010443865
-        assert responses[0].testPointProperties.centerY == 10.578305680323764
+        assert responses[0].testPointProperties.centerX == pytest.approx(53.09614010443865, abs=1e-6)
+        assert responses[0].testPointProperties.centerY == pytest.approx(10.578305680323764, abs=1e-6)
         assert responses[0].testPointProperties.radius == 1
         assert responses[0].testPointProperties.loadType == 0
         assert responses[0].testPointProperties.loadValue == 0.36
@@ -1591,8 +1591,8 @@ def helper_test_get_test_point_props(layer):
         assert responses[1].testPointProperties.ID == "TP2"
         assert responses[1].testPointProperties.side == "TOP"
         assert responses[1].testPointProperties.units == "mm"
-        assert responses[1].testPointProperties.centerX == 71.21625140992168
-        assert responses[1].testPointProperties.centerY == 10.718771659436035
+        assert responses[1].testPointProperties.centerX == pytest.approx(71.21625140992168, abs=1e-6)
+        assert responses[1].testPointProperties.centerY == pytest.approx(10.718771659436035, abs=1e-6)
         assert responses[1].testPointProperties.radius == 1
         assert responses[1].testPointProperties.loadType == 0
         assert responses[1].testPointProperties.loadValue == 0.36
@@ -1616,8 +1616,8 @@ def helper_test_get_test_point_props(layer):
         assert mixedResponses[2].testPointProperties.ID == "TP1"
         assert mixedResponses[2].testPointProperties.side == "TOP"
         assert mixedResponses[2].testPointProperties.units == "mm"
-        assert mixedResponses[2].testPointProperties.centerX == 53.09614010443865
-        assert mixedResponses[2].testPointProperties.centerY == 10.578305680323764
+        assert mixedResponses[2].testPointProperties.centerX == pytest.approx(53.09614010443865, abs=1e-6)
+        assert mixedResponses[2].testPointProperties.centerY == pytest.approx(10.578305680323764, abs=1e-6)
         assert mixedResponses[2].testPointProperties.radius == 1
         assert mixedResponses[2].testPointProperties.loadType == 0
         assert mixedResponses[2].testPointProperties.loadValue == 0.36
@@ -1626,8 +1626,8 @@ def helper_test_get_test_point_props(layer):
         assert mixedResponses[3].testPointProperties.ID == "TP2"
         assert mixedResponses[3].testPointProperties.side == "TOP"
         assert mixedResponses[3].testPointProperties.units == "mm"
-        assert mixedResponses[3].testPointProperties.centerX == 71.21625140992168
-        assert mixedResponses[3].testPointProperties.centerY == 10.718771659436035
+        assert mixedResponses[3].testPointProperties.centerX == pytest.approx(71.21625140992168, abs=1e-6)
+        assert mixedResponses[3].testPointProperties.centerY == pytest.approx(10.718771659436035, abs=1e-6)
         assert mixedResponses[3].testPointProperties.radius == 1
         assert mixedResponses[3].testPointProperties.loadType == 0
         assert mixedResponses[3].testPointProperties.loadValue == 0.36
@@ -1645,8 +1645,8 @@ def helper_test_get_test_point_props(layer):
         assert allPointsResponses[0].testPointProperties.ID == "TP1"
         assert allPointsResponses[0].testPointProperties.side == "TOP"
         assert allPointsResponses[0].testPointProperties.units == "mm"
-        assert allPointsResponses[0].testPointProperties.centerX == 53.09614010443865
-        assert allPointsResponses[0].testPointProperties.centerY == 10.578305680323764
+        assert allPointsResponses[0].testPointProperties.centerX == pytest.approx(53.09614010443865, abs=1e-6)
+        assert allPointsResponses[0].testPointProperties.centerY == pytest.approx(10.578305680323764, abs=1e-6)
         assert allPointsResponses[0].testPointProperties.radius == 1
         assert allPointsResponses[0].testPointProperties.loadType == 0
         assert allPointsResponses[0].testPointProperties.loadValue == 0.36
@@ -1654,8 +1654,8 @@ def helper_test_get_test_point_props(layer):
 
         assert allPointsResponses[1].testPointProperties.side == "TOP"
         assert allPointsResponses[1].testPointProperties.units == "mm"
-        assert allPointsResponses[1].testPointProperties.centerX == 71.21625140992168
-        assert allPointsResponses[1].testPointProperties.centerY == 10.718771659436035
+        assert allPointsResponses[1].testPointProperties.centerX == pytest.approx(71.21625140992168, abs=1e-6)
+        assert allPointsResponses[1].testPointProperties.centerY == pytest.approx(10.718771659436035, abs=1e-6)
         assert allPointsResponses[1].testPointProperties.radius == 1
         assert allPointsResponses[1].testPointProperties.loadType == 0
         assert allPointsResponses[1].testPointProperties.loadValue == 0.36
@@ -1664,8 +1664,8 @@ def helper_test_get_test_point_props(layer):
         assert allPointsResponses[2].testPointProperties.ID == "TP3"
         assert allPointsResponses[2].testPointProperties.side == "TOP"
         assert allPointsResponses[2].testPointProperties.units == "mm"
-        assert allPointsResponses[2].testPointProperties.centerX == 71.21625140992168
-        assert allPointsResponses[2].testPointProperties.centerY == -10.632057165629243
+        assert allPointsResponses[2].testPointProperties.centerX == pytest.approx(71.21625140992168, abs=1e-6)
+        assert allPointsResponses[2].testPointProperties.centerY == pytest.approx(-10.632057165629243, abs=1e-6)
         assert allPointsResponses[2].testPointProperties.radius == 1
         assert allPointsResponses[2].testPointProperties.loadType == 0
         assert allPointsResponses[2].testPointProperties.loadValue == 0.36
@@ -1674,8 +1674,8 @@ def helper_test_get_test_point_props(layer):
         assert allPointsResponses[3].testPointProperties.ID == "TP4"
         assert allPointsResponses[3].testPointProperties.side == "TOP"
         assert allPointsResponses[3].testPointProperties.units == "mm"
-        assert allPointsResponses[3].testPointProperties.centerX == 53.09614010443865
-        assert allPointsResponses[3].testPointProperties.centerY == -10.632057165629243
+        assert allPointsResponses[3].testPointProperties.centerX == pytest.approx(53.09614010443865, abs=1e-6)
+        assert allPointsResponses[3].testPointProperties.centerY == pytest.approx(-10.632057165629243, abs=1e-6)
         assert allPointsResponses[3].testPointProperties.radius == 1
         assert allPointsResponses[3].testPointProperties.loadType == 0
         assert allPointsResponses[3].testPointProperties.loadValue == 0.36


### PR DESCRIPTION
## Description
Use pytest.approx() for floating point values in layer_tests.

## Issue linked
https://github.com/ansys/pysherlock/issues/595

## Checklist:
- [] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [] Generate documentation
- [] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [] Check that test code coverage is at least 80% when Sherlock is running
- [] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
