### PR TITLE
0.6 release: ci_cd.yml- remove "docs-style" dependency since "docs-style" is no longer defined

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -113,7 +113,7 @@ jobs:
 
   docs:
     name: Documentation
-    needs: [ docs-style ]
+#    needs: [ docs-style ]
     runs-on: ubuntu-latest
     steps:
       - name: Run documentation building action

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -111,19 +111,20 @@ jobs:
         with:
           files: .cov/coverage.xml
 
-  docs:
-    name: Documentation
+#  docs:
+#    name: Documentation
 #    needs: [ docs-style ]
-    runs-on: ubuntu-latest
-    steps:
-      - name: Run documentation building action
-        uses: ansys/actions/doc-build@v7
-        with:
-          python-version: ${{ env.MAIN_PYTHON_VERSION }}
+#    runs-on: ubuntu-latest
+#    steps:
+#      - name: Run documentation building action
+#        uses: ansys/actions/doc-build@v7
+#        with:
+#          python-version: ${{ env.MAIN_PYTHON_VERSION }}
 
   package:
     name: Package library
-    needs: [ tests, docs ]
+#    needs: [ tests, docs ]
+    needs: [ tests ]
     runs-on: ubuntu-latest
     steps:
       - name: Build library source and wheel artifacts


### PR DESCRIPTION
0.6 release: ci_cd.yml- remove "docs-style" dependency since "docs-style" is no longer defined