### PR TITLE
fix: fixed bug in update_parts_list_properties()

### DIFF
--- a/doc/changelog.d/772.fixed.md
+++ b/doc/changelog.d/772.fixed.md
@@ -1,0 +1,1 @@
+Fix: fixed bug in update_parts_list_properties()

--- a/src/ansys/sherlock/core/errors.py
+++ b/src/ansys/sherlock/core/errors.py
@@ -27,6 +27,8 @@
 from builtins import Exception
 from typing import Optional
 
+from ansys.api.sherlock.v0 import SherlockPartsService_pb2
+
 LOCALHOST = "127.0.0.1"
 SHERLOCK_DEFAULT_PORT = 9090
 
@@ -1017,7 +1019,15 @@ class SherlockImportProjectZipArchiveSingleModeError(Exception):
 class SherlockUpdatePartsListPropertiesError(Exception):
     """Contains the errors raised when a parts list properties cannot be updated."""
 
-    def __init__(self, message: Optional[str] = None, update_errors: Optional[list] = None):
+    def __init__(
+        self,
+        message: Optional[str] = None,
+        update_errors: Optional[
+            list[
+                SherlockPartsService_pb2.UpdatePartsListPropertiesResponse.PartPropertyError
+            ]
+        ] = None,
+    ):
         """Initialize error message."""
         self.message = message
         self.update_errors = update_errors

--- a/src/ansys/sherlock/core/errors.py
+++ b/src/ansys/sherlock/core/errors.py
@@ -1023,9 +1023,7 @@ class SherlockUpdatePartsListPropertiesError(Exception):
         self,
         message: Optional[str] = None,
         update_errors: Optional[
-            list[
-                SherlockPartsService_pb2.UpdatePartsListPropertiesResponse.PartPropertyError
-            ]
+            list[SherlockPartsService_pb2.UpdatePartsListPropertiesResponse.PartPropertyError]
         ] = None,
     ):
         """Initialize error message."""

--- a/src/ansys/sherlock/core/errors.py
+++ b/src/ansys/sherlock/core/errors.py
@@ -1017,15 +1017,22 @@ class SherlockImportProjectZipArchiveSingleModeError(Exception):
 class SherlockUpdatePartsListPropertiesError(Exception):
     """Contains the errors raised when a parts list properties cannot be updated."""
 
-    def __init__(self, message: Optional[str] = None, error_array: Optional[list[str]] = None):
+    def __init__(self, message: Optional[str] = None, update_errors: Optional[list] = None):
         """Initialize error message."""
         self.message = message
-        self.error_array = error_array
+        self.update_errors = update_errors
 
     def str_itr(self):
         """Format error message."""
-        if self.error_array is not None:
-            return [f"Update parts list properties error: {error}" for error in self.error_array]
+        if self.update_errors is not None:
+            errors = []
+            for error in self.update_errors:
+                ref_des = getattr(error, "refDes", "")
+                if ref_des:
+                    errors.append(f"Update parts list properties error: {ref_des}: {error.message}")
+                else:
+                    errors.append(f"Update parts list properties error: {error.message}")
+            return errors
 
         elif self.message is not None:
             return [f"Update parts list properties error: {self.message}"]

--- a/src/ansys/sherlock/core/parts.py
+++ b/src/ansys/sherlock/core/parts.py
@@ -262,7 +262,7 @@ class Parts(GrpcStub):
         try:
             if return_code.value == -1:
                 if return_code.message == "":
-                    raise SherlockUpdatePartsListError(error_array=response.errors)
+                    raise SherlockUpdatePartsListError(error_array=response.updateError)
 
                 raise SherlockUpdatePartsListError(message=return_code.message)
             else:
@@ -941,7 +941,7 @@ class Parts(GrpcStub):
 
             if return_code.value == -1:
                 if return_code.message == "":
-                    raise SherlockUpdatePartsListPropertiesError(error_array=response.errors)
+                    raise SherlockUpdatePartsListPropertiesError(error_array=response.updateErrors)
 
                 raise SherlockUpdatePartsListPropertiesError(message=return_code.message)
 

--- a/src/ansys/sherlock/core/parts.py
+++ b/src/ansys/sherlock/core/parts.py
@@ -261,13 +261,10 @@ class Parts(GrpcStub):
 
         try:
             if return_code.value == -1:
-                if return_code.message == "":
-                    raise SherlockUpdatePartsListError(error_array=response.updateError)
-
                 raise SherlockUpdatePartsListError(message=return_code.message)
-            else:
-                LOG.info(return_code.message)
-                return return_code.value
+
+            return return_code.value
+        
         except SherlockUpdatePartsListError as e:
             for error in e.str_itr():
                 LOG.error(error)
@@ -940,9 +937,6 @@ class Parts(GrpcStub):
             return_code = response.returnCode
 
             if return_code.value == -1:
-                if return_code.message == "":
-                    raise SherlockUpdatePartsListPropertiesError(error_array=response.updateErrors)
-
                 raise SherlockUpdatePartsListPropertiesError(message=return_code.message)
 
             return return_code.value

--- a/src/ansys/sherlock/core/parts.py
+++ b/src/ansys/sherlock/core/parts.py
@@ -264,7 +264,7 @@ class Parts(GrpcStub):
                 raise SherlockUpdatePartsListError(message=return_code.message)
 
             return return_code.value
-        
+
         except SherlockUpdatePartsListError as e:
             for error in e.str_itr():
                 LOG.error(error)

--- a/src/ansys/sherlock/core/parts.py
+++ b/src/ansys/sherlock/core/parts.py
@@ -937,7 +937,9 @@ class Parts(GrpcStub):
             return_code = response.returnCode
 
             if return_code.value == -1:
-                raise SherlockUpdatePartsListPropertiesError(message=return_code.message)
+                raise SherlockUpdatePartsListPropertiesError(
+                    message=return_code.message, update_errors=list(response.updateErrors)
+                )
 
             return return_code.value
 

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -146,8 +146,7 @@ def helper_test_update_parts_list(parts: Parts):
     # Test the returnCode.value == -1 with empty message and errors in updateError
     mock_response = MagicMock()
     mock_response.returnCode.value = -1
-    mock_response.returnCode.message = ""
-    mock_response.updateError = ["Error: part not found"]
+    mock_response.returnCode.message = "Error: part not found"
     with patch.object(parts, "_is_connection_up", return_value=True):
         with patch.object(parts.stub, "updatePartsList", return_value=mock_response):
             try:
@@ -159,8 +158,8 @@ def helper_test_update_parts_list(parts: Parts):
                     PartsListSearchDuplicationMode.ERROR,
                 )
                 pytest.fail("No exception raised when server returns errors")
-            except SherlockUpdatePartsListError:
-                pass
+            except SherlockUpdatePartsListError as e:
+                assert e.message == "Error: part not found"
 
 
 def helper_test_update_parts_from_AVL(parts: Parts):
@@ -856,10 +855,13 @@ def helper_test_update_parts_list_properties(parts: Parts):
         assert str(e.str_itr()) == ("['Update parts list properties error: Value is invalid.']")
 
     # Test the  returnCode.value == -1 with empty message and errors in updateErrors
+    mock_error = MagicMock()
+    mock_error.refDes = "C1"
+    mock_error.message = "unknown property"
     mock_response = MagicMock()
     mock_response.returnCode.value = -1
-    mock_response.returnCode.message = ""
-    mock_response.updateErrors = ["Error updating C1: unknown property"]
+    mock_response.returnCode.message = "C1: unknown property"
+    mock_response.updateErrors = [mock_error]
     with patch.object(parts, "_is_connection_up", return_value=True):
         with patch.object(parts.stub, "updatePartsListProperties", return_value=mock_response):
             try:
@@ -874,8 +876,8 @@ def helper_test_update_parts_list_properties(parts: Parts):
                     ],
                 )
                 pytest.fail("No exception raised when server returns errors")
-            except SherlockUpdatePartsListPropertiesError:
-                pass
+            except SherlockUpdatePartsListPropertiesError as e:
+                assert e.message == "C1: unknown property"
 
     if not parts._is_connection_up():
         return

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -24,6 +24,7 @@
 
 import os
 import platform
+from unittest.mock import MagicMock, patch
 
 from ansys.api.sherlock.v0 import SherlockPartsService_pb2
 import grpc
@@ -141,6 +142,25 @@ def helper_test_update_parts_list(parts: Parts):
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockUpdatePartsListError as e:
         assert str(e.str_itr()) == "['Update parts list error: Parts library is invalid.']"
+
+    # Test the returnCode.value == -1 with empty message and errors in updateError
+    mock_response = MagicMock()
+    mock_response.returnCode.value = -1
+    mock_response.returnCode.message = ""
+    mock_response.updateError = ["Error: part not found"]
+    with patch.object(parts, "_is_connection_up", return_value=True):
+        with patch.object(parts.stub, "updatePartsList", return_value=mock_response):
+            try:
+                parts.update_parts_list(
+                    "Test",
+                    "Card",
+                    "Sherlock Part Library",
+                    "Both",
+                    PartsListSearchDuplicationMode.ERROR,
+                )
+                pytest.fail("No exception raised when server returns errors")
+            except SherlockUpdatePartsListError:
+                pass
 
 
 def helper_test_update_parts_from_AVL(parts: Parts):
@@ -834,6 +854,28 @@ def helper_test_update_parts_list_properties(parts: Parts):
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockUpdatePartsListPropertiesError as e:
         assert str(e.str_itr()) == ("['Update parts list properties error: Value is invalid.']")
+
+    # Test the  returnCode.value == -1 with empty message and errors in updateErrors
+    mock_response = MagicMock()
+    mock_response.returnCode.value = -1
+    mock_response.returnCode.message = ""
+    mock_response.updateErrors = ["Error updating C1: unknown property"]
+    with patch.object(parts, "_is_connection_up", return_value=True):
+        with patch.object(parts.stub, "updatePartsListProperties", return_value=mock_response):
+            try:
+                parts.update_parts_list_properties(
+                    "Test",
+                    "Card",
+                    [
+                        {
+                            "reference_designators": ["C1"],
+                            "properties": [{"name": "partType", "value": "RESISTOR"}],
+                        }
+                    ],
+                )
+                pytest.fail("No exception raised when server returns errors")
+            except SherlockUpdatePartsListPropertiesError:
+                pass
 
     if not parts._is_connection_up():
         return

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -882,9 +882,7 @@ def helper_test_update_parts_list_properties(parts: Parts):
                 assert e.update_errors == mock_response.updateErrors
 
     # Validate str_itr() formatting with update_errors
-    PartPropertyError = (
-        SherlockPartsService_pb2.UpdatePartsListPropertiesResponse.PartPropertyError
-    )
+    PartPropertyError = SherlockPartsService_pb2.UpdatePartsListPropertiesResponse.PartPropertyError
     mock_error_with_ref_des = PartPropertyError(refDes="C1", message="unknown property")
     mock_error_no_ref_des = PartPropertyError(refDes="", message="invalid property name")
 

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -882,17 +882,11 @@ def helper_test_update_parts_list_properties(parts: Parts):
                 assert e.update_errors == mock_response.updateErrors
 
     # Validate str_itr() formatting with update_errors
-    mock_error_with_ref_des = MagicMock()
-    mock_error_with_ref_des.refDes = "C1"
-    mock_error_with_ref_des.message = "unknown property"
-    e = SherlockUpdatePartsListPropertiesError(update_errors=[mock_error_with_ref_des])
-    assert e.str_itr() == ["Update parts list properties error: C1: unknown property"]
-
-    mock_error_no_ref_des = MagicMock()
-    mock_error_no_ref_des.refDes = ""
-    mock_error_no_ref_des.message = "invalid property name"
-    e = SherlockUpdatePartsListPropertiesError(update_errors=[mock_error_no_ref_des])
-    assert e.str_itr() == ["Update parts list properties error: invalid property name"]
+    PartPropertyError = (
+        SherlockPartsService_pb2.UpdatePartsListPropertiesResponse.PartPropertyError
+    )
+    mock_error_with_ref_des = PartPropertyError(refDes="C1", message="unknown property")
+    mock_error_no_ref_des = PartPropertyError(refDes="", message="invalid property name")
 
     e = SherlockUpdatePartsListPropertiesError(
         update_errors=[mock_error_with_ref_des, mock_error_no_ref_des]

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -881,6 +881,27 @@ def helper_test_update_parts_list_properties(parts: Parts):
                 assert e.message == mock_response.returnCode.message
                 assert e.update_errors == mock_response.updateErrors
 
+    # Validate str_itr() formatting with update_errors
+    mock_error_with_ref_des = MagicMock()
+    mock_error_with_ref_des.refDes = "C1"
+    mock_error_with_ref_des.message = "unknown property"
+    e = SherlockUpdatePartsListPropertiesError(update_errors=[mock_error_with_ref_des])
+    assert e.str_itr() == ["Update parts list properties error: C1: unknown property"]
+
+    mock_error_no_ref_des = MagicMock()
+    mock_error_no_ref_des.refDes = ""
+    mock_error_no_ref_des.message = "invalid property name"
+    e = SherlockUpdatePartsListPropertiesError(update_errors=[mock_error_no_ref_des])
+    assert e.str_itr() == ["Update parts list properties error: invalid property name"]
+
+    e = SherlockUpdatePartsListPropertiesError(
+        update_errors=[mock_error_with_ref_des, mock_error_no_ref_des]
+    )
+    assert e.str_itr() == [
+        "Update parts list properties error: C1: unknown property",
+        "Update parts list properties error: invalid property name",
+    ]
+
     if not parts._is_connection_up():
         return
 

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -854,14 +854,15 @@ def helper_test_update_parts_list_properties(parts: Parts):
     except SherlockUpdatePartsListPropertiesError as e:
         assert str(e.str_itr()) == ("['Update parts list properties error: Value is invalid.']")
 
-    # Test the  returnCode.value == -1 with empty message and errors in updateErrors
-    mock_error = MagicMock()
-    mock_error.refDes = "C1"
-    mock_error.message = "unknown property"
+    # Test that SherlockUpdatePartsListPropertiesError is raised with the returnCode message
+    # and updateErrors from the response when returnCode.value == -1
+    mock_part_property_error = MagicMock()
+    mock_part_property_error.refDes = "C1"
+    mock_part_property_error.message = "unknown property"
     mock_response = MagicMock()
     mock_response.returnCode.value = -1
-    mock_response.returnCode.message = "C1: unknown property"
-    mock_response.updateErrors = [mock_error]
+    mock_response.returnCode.message = "Error updating parts list"
+    mock_response.updateErrors = [mock_part_property_error]
     with patch.object(parts, "_is_connection_up", return_value=True):
         with patch.object(parts.stub, "updatePartsListProperties", return_value=mock_response):
             try:
@@ -877,7 +878,8 @@ def helper_test_update_parts_list_properties(parts: Parts):
                 )
                 pytest.fail("No exception raised when server returns errors")
             except SherlockUpdatePartsListPropertiesError as e:
-                assert e.message == "C1: unknown property"
+                assert e.message == mock_response.returnCode.message
+                assert e.update_errors == mock_response.updateErrors
 
     if not parts._is_connection_up():
         return


### PR DESCRIPTION
## Description
Resolved issues with error message handling in the update_parts_list_properties() and update_parts_list() API methods.

## Issue linked
#771 

## Checklist:
- [x] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [x] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [ ] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [ ] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [x] Check that test code coverage is at least 80% when Sherlock is running
- [x] Check vulnerabilities locally
- [x] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
