### PR TITLE
docs: ignore linkcheck on repository links

### DIFF
--- a/doc/changelog.d/773.documentation.md
+++ b/doc/changelog.d/773.documentation.md
@@ -1,0 +1,1 @@
+Docs: ignore linkcheck on repository links

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -140,7 +140,12 @@ latex_additional_files = [watermark, ansys_logo_white, ansys_logo_white_cropped]
 # variables are the title of pdf, watermark
 latex_elements = {"preamble": latex.generate_preamble(html_title)}
 
-linkcheck_ignore = ["https://www.ansys.com/*"]
+linkcheck_exclude_documents = ["changelog"]
+linkcheck_ignore = [
+    "https://github.com/ansys/pysherlock/.*",
+    "https://opensource.org/licenses/MIT",
+    "https://www.ansys.com/*",
+]
 
 # If we are on a release, we have to ignore the "release" URLs, since it is not
 # available until the release is published.


### PR DESCRIPTION
## Description
Ignore checking PR links in the changelog.

## Checklist:
- [na] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [na] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [na] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [na] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [na] Check that test code coverage is at least 80% when Sherlock is running
- [na] Check vulnerabilities locally
- [x] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
