### PR TITLE
feat: Added ThermalMech to exportFEAModel and updated documentation for LeadModelParam.leadElemOrder

### DIFF
--- a/doc/changelog.d/780.added.md
+++ b/doc/changelog.d/780.added.md
@@ -1,1 +1,1 @@
-FEAT: Added ThermalMech to exportFEAModel and updated documentation for LeadModelParam.leadElemOrder
+Feat: Added ThermalMech to exportFEAModel and updated documentation for LeadModelParam.leadElemOrder

--- a/doc/changelog.d/780.added.md
+++ b/doc/changelog.d/780.added.md
@@ -1,0 +1,1 @@
+FEAT: Added ThermalMech to exportFEAModel and updated documentation for LeadModelParam.leadElemOrder

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ansys-api-sherlock==0.2.1",
+    "ansys-api-sherlock==0.2.2",
     "grpcio>=1.71.2",
     "protobuf>=5.29.6",
     "pydantic>=2.9.2"

--- a/src/ansys/sherlock/core/model.py
+++ b/src/ansys/sherlock/core/model.py
@@ -701,7 +701,8 @@ class Model(GrpcStub):
             Full path for saving exported files to. The file extension must be ``.wbjn``.
         analysis: str
             The type of analysis that is being exported. Valid values are ``NaturalFreq``,
-            ``HarmonicVibe``, ``ICTAnalysis``, ``MechanicalShock`` or ``RandomVibe``.
+            ``HarmonicVibe``, ``ICTAnalysis``, ``MechanicalShock``, ``RandomVibe``, or
+            ``ThermalMech``.
         drill_hole_parameters: list[dict[str, str | Measurement]]
             List of the drill hole parameters consisting of these properties:
 
@@ -725,7 +726,8 @@ class Model(GrpcStub):
                     modeling. Valid values are ``ENABLED`` or ``DISABLED``.
                 - lead_element_order: str
                      The type of the element order. Valid values are ``First Order (Linear)``,
-                     ``Second Order (Quadratic)``, or ``Solid Shell``.
+                     ``Second Order (Quadratic)``, ``Solid Shell``, or ``Shells And Beam``
+                     for CDB export only.
                 - max_mesh_size: MaxMeshSize
                     The properties of the maximum mesh size.
                 - vertical_mesh_size: VerticalMeshSize


### PR DESCRIPTION
## Description
Added ThermalMech to exportFEAModel and updated documentation for LeadModelParam.leadElemOrder

## Issue linked
Resolves #779 

## Checklist:
- [ ] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [ ] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [ ] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [ ] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [ ] Generate documentation
- [ ] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [ ] Check that test code coverage is at least 80% when Sherlock is running
- [ ] Check vulnerabilities locally
- [ ] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
