### PR TITLE
build: add support for python 3.14

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  MAIN_PYTHON_VERSION: '3.13'
+  MAIN_PYTHON_VERSION: '3.14'
   PACKAGE_NAME: 'ansys-sherlock-core'
   PACKAGE_NAMESPACE: 'ansys.sherlock.core'
   DOCUMENTATION_CNAME: 'sherlock.docs.pyansys.com'
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:
@@ -73,7 +73,7 @@ jobs:
     runs-on: [ self-hosted, pysherlock ]
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/doc/changelog.d/781.added.md
+++ b/doc/changelog.d/781.added.md
@@ -1,0 +1,1 @@
+Feat: add support for python 3.14

--- a/doc/changelog.d/781.added.md
+++ b/doc/changelog.d/781.added.md
@@ -1,1 +1,0 @@
-Feat: add support for python 3.14

--- a/doc/changelog.d/781.documentation.md
+++ b/doc/changelog.d/781.documentation.md
@@ -1,0 +1,1 @@
+Build: add support for python 3.14

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -171,7 +171,7 @@ archive from the `Releases Page <https://github.com/ansys/pysherlock/releases>`_
 corresponding machine architecture.
 
 Each wheelhouse archive contains all the Python wheels necessary to install PySherlock from scratch on Windows,
-Linux, and MacOS from Python 3.10 to 3.13. You can install this on an isolated system with a fresh Python
+Linux, and MacOS from Python 3.10 to 3.14. You can install this on an isolated system with a fresh Python
 installation or on a virtual environment.
 
 For example, on Linux with Python 3.10, unzip the wheelhouse archive and install it with:

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -4,7 +4,7 @@
 Install packages
 ================
 
-The ``ansys-sherlock-core`` package supports Python 3.10 through Python 3.13 on Windows and Linux.
+The ``ansys-sherlock-core`` package supports Python 3.10 through Python 3.14 on Windows and Linux.
 
 To use PySherlock, you must download and install both the ``ansys-api-sherlock``
 and ``ansys-sherlock-core`` packages. By using ``pip``, ``ansys-api-sherlock`` is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,21 +26,21 @@ classifiers = [
 
 dependencies = [
     "ansys-api-sherlock==0.2.2",
-    "grpcio>=1.71.2",
-    "protobuf>=6.31.1",
+    "grpcio>=1.78.0",
+    "protobuf>=6.31.1,<7.0.0",
     "pydantic>=2.9.2"
 ]
 
 [project.optional-dependencies]
 tests = [
-    "grpcio==1.78.0",
-    "protobuf==6.31.1",
+    "grpcio==1.78.0", # same version as in dependencies to avoid compatibility issues
+    "protobuf==6.31.1", # same version as in dependencies to avoid compatibility issues
     "pytest==9.0.3",
     "pytest-cov==7.1.0"
 ]
 
 dev = [
-    "grpcio-tools==1.78.0",
+    "grpcio-tools==1.78.0", # same version as in dependencies to avoid compatibility issues
 ]
 
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,23 +20,29 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
-    "Programming Language :: Python :: 3.13"
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14"
 ]
 
 dependencies = [
     "ansys-api-sherlock==0.2.2",
     "grpcio>=1.71.2",
-    "protobuf>=5.29.6",
+    "protobuf>=6.31.1",
     "pydantic>=2.9.2"
 ]
 
 [project.optional-dependencies]
 tests = [
     "grpcio==1.78.0",
-    "protobuf==7.34.0",
+    "protobuf==6.31.1",
     "pytest==9.0.3",
     "pytest-cov==7.1.0"
 ]
+
+dev = [
+    "grpcio-tools==1.78.0",
+]
+
 doc = [
     "ansys-sphinx-theme==1.7.2",
     "jupyter_sphinx==0.5.3",


### PR DESCRIPTION
## Description
Modify CI to run tests for Python 3.14.
Modify documentation to indicate that PySherlock can run on Python 3.14.
Modify dependencies to help enforce compatibility for gRPC and Protobuf for end users.

## Issue linked
#733 

## Checklist:
- [x] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [na] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [na] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [x] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [x] Check that test code coverage is at least 80% when Sherlock is running
- [na] Check vulnerabilities locally
- [x] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
