### PR TITLE
feat: add Max Mesh Size fields to request to update trace modeling properties

### DIFF
--- a/doc/changelog.d/824.added.md
+++ b/doc/changelog.d/824.added.md
@@ -1,0 +1,1 @@
+Feat: add Max Mesh Size fields to request to update trace modeling properties

--- a/examples/03-exporting/export_fea_model.py
+++ b/examples/03-exporting/export_fea_model.py
@@ -39,7 +39,7 @@ This script demonstrates how to:
 
 import os
 
-from ansys.api.sherlock.v0.SherlockModelService_pb2 import GeometryType, PcbMaterialElasticity
+from ansys.api.sherlock.v0.SherlockModelService_pb2 import GeometryType, PcbMaterialType
 from examples.examples_globals import get_sherlock_tutorial_path, get_temp_dir
 
 from ansys.sherlock.core import launcher
@@ -116,7 +116,7 @@ try:
         clear_FEA_database=True,
         use_FEA_model_id=True,
         coordinate_units="mm",
-        pcb_material_elasticity=PcbMaterialElasticity.Orthotropic,
+        pcb_material_type=PcbMaterialType.Orthotropic,
         geometry_type=GeometryType.Step,
     )
     print(f"FEA model exported successfully to: {fea_export_path}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ansys-api-sherlock==1.1.0",
+    "ansys-api-sherlock==2.0.1",
     "grpcio>=1.80.0",
     "protobuf>=6.33.5,<7", # avoid DoS vulnerability in >= 6.30.0rc1, <= 6.33.4
     "pydantic>=2.9.2",

--- a/src/ansys/sherlock/core/analysis.py
+++ b/src/ansys/sherlock/core/analysis.py
@@ -1861,6 +1861,8 @@ class Analysis(GrpcStub):
         >>>     analysis_type=AnalysisService.UpdateTraceModelingPropsRequest.Analysis.ICTAnalysis,
         >>>     trace_enabled=True,
         >>>     trace_element_order=AnalysisService.ElementOrder.Quadratic,
+        >>>     trace_max_edge_length=0.2,
+        >>>     trace_max_edge_length_units="mm",
         >>>     trace_max_holes=5,
         >>> )
         >>> request = UpdateTraceModelingPropsRequest(

--- a/src/ansys/sherlock/core/model.py
+++ b/src/ansys/sherlock/core/model.py
@@ -29,7 +29,7 @@ from ansys.api.sherlock.v0 import SherlockModelService_pb2, SherlockModelService
 from ansys.api.sherlock.v0.SherlockModelService_pb2 import (
     GeometryType,
     MeshType,
-    PcbMaterialElasticity,
+    PcbMaterialType,
     TraceOutputType,
 )
 import grpc
@@ -155,16 +155,16 @@ class Model(GrpcStub):
         >>> from ansys.sherlock.core import launcher
         >>> from ansys.sherlock.core import model
         >>> sherlock.model.export_trace_reinforcement_model(
-            'Tutorial Project', 'Main Board', 'c:\Temp\export.wbjn',
-            True, False, False)
-
+        >>>     'Tutorial Project', 'Main Board', 'c:\Temp\export.wbjn',
+        >>>     True, False, False)
+        >>>
         >>> from ansys.sherlock.core import launcher
         >>> from ansys.sherlock.core import model
         >>> from ansys.sherlock.core import launcher
         >>> sherlock, install_dir = launcher.launch_and_connect(transport_mode="wnua")
         >>> sherlock.model.export_trace_reinforcement_model(
-            'Tutorial Project', 'Main Board', 'c:\Temp\export.wbjn',
-            True, False, False, "mm", 1.5, "mm", 0, "mm", "ENABLED", 1.5, "mm", 1, "mm")
+        >>>     'Tutorial Project', 'Main Board', 'c:\Temp\export.wbjn',
+        >>>     True, False, False, "mm", 1.5, "mm", 0, "mm", "ENABLED", 1.5, "mm", 1, "mm")
         """
         try:
             if not project_name:
@@ -302,8 +302,8 @@ class Model(GrpcStub):
         >>> from ansys.sherlock.core import launcher
         >>> sherlock, install_dir = launcher.launch_and_connect(transport_mode="wnua")
         >>> sherlock.model.generate_trace_model(
-            'Tutorial Project', 'Main Board', 0.05, 'mm'
-            0.0, 'mm2', 0.0, 'mm2')
+        >>>     'Tutorial Project', 'Main Board', 0.05, 'mm'
+        >>>     0.0, 'mm2', 0.0, 'mm2')
 
         """
         try:
@@ -378,8 +378,8 @@ class Model(GrpcStub):
         >>> from ansys.sherlock.core import launcher
         >>> sherlock, install_dir = launcher.launch_and_connect(transport_mode="wnua")
         >>> sherlock.model.export_aedb(
-            'Tutorial Project', 'Main Board', 'c:\Temp\export.aedb',
-            True, False)
+        >>>     'Tutorial Project', 'Main Board', 'c:\Temp\export.aedb',
+        >>>     True, False)
         """
         try:
             if not project_name:
@@ -580,51 +580,49 @@ class Model(GrpcStub):
         >>> from ansys.sherlock.core import launcher
         >>> sherlock, install_dir = launcher.launch_and_connect(transport_mode="wnua")
         >>> copper_1_layer = sherlock.model.createExportTraceCopperLayerParams(
-                "Tutorial Project",
-                "Main Board",
-                ".\\outputfile_path.stp",
-                "copper-01.odb",
-                False,
-                False,
-                False,
-                False,
-                "mm",
-                SherlockModelService_pb2.MeshType.NONE,
-                False,
-                SherlockModelService_pb2.TraceOutputType.ALL_REGIONS,
-                ElementOrder.LINEAR,
-                1.0,
-                "mm",
-                2,
-                False,
-                1.0,
-                "mm",
-                1.0,
-                GeometryType.Step
-            )
+        >>>     "Tutorial Project",
+        >>>     "Main Board",
+        >>>     ".\\outputfile_path.stp",
+        >>>     "copper-01.odb",
+        >>>     False,
+        >>>     False,
+        >>>     False,
+        >>>     False,
+        >>>     "mm",
+        >>>     SherlockModelService_pb2.MeshType.NONE,
+        >>>     False,
+        >>>     SherlockModelService_pb2.TraceOutputType.ALL_REGIONS,
+        >>>     ElementOrder.LINEAR,
+        >>>     1.0,
+        >>>     "mm",
+        >>>     2,
+        >>>     False,
+        >>>     1.0,
+        >>>     "mm",
+        >>>     1.0,
+        >>>     GeometryType.Step
+        >>> )
         >>> copper_2_layer = sherlock.model.createExportTraceCopperLayerParams(
-                "Tutorial Project",
-                "Main Board",
-                ".\\outputfile_path2.stp",
-                "copper-02.odb",
-                False,
-                False,
-                False,
-                False,
-                "mm",
-                SherlockModelService_pb2.MeshType.NONE,
-                False,
-                SherlockModelService_pb2.TraceOutputType.ALL_REGIONS,
-                ElementOrder.LINEAR,
-                1.0,
-                "mm",
-                2,
-                False,
-                1.0,
-                "mm",
-                1.0,
-                GeometryType.Step
-            )
+        >>>     "Tutorial Project",
+        >>>     "Main Board",
+        >>>     ".\\outputfile_path2.stp",
+        >>>     "copper-02.odb",
+        >>>     False,
+        >>>     False,
+        >>>     "mm",
+        >>>     SherlockModelService_pb2.MeshType.NONE,
+        >>>     False,
+        >>>     SherlockModelService_pb2.TraceOutputType.ALL_REGIONS,
+        >>>     ElementOrder.LINEAR,
+        >>>     1.0,
+        >>>     "mm",
+        >>>     2,
+        >>>     False,
+        >>>     1.0,
+        >>>     "mm",
+        >>>     1.0,
+        >>>     GeometryType.Step
+        >>> )
         >>> sherlock.model.exportTraceModel([copper_1_layer, copper_2_layer])
         """
         try:
@@ -689,7 +687,7 @@ class Model(GrpcStub):
         clear_FEA_database: bool,
         use_FEA_model_id: bool,
         coordinate_units: str,
-        pcb_material_elasticity: PcbMaterialElasticity = PcbMaterialElasticity.Isotropic,
+        pcb_material_type: PcbMaterialType = PcbMaterialType.Isotropic,
         geometry_type: GeometryType = GeometryType.Step,
     ) -> int:
         """
@@ -752,9 +750,9 @@ class Model(GrpcStub):
             Whether to use FEA model ID.
         coordinate_units: str
             Units of the model coordinates to use when exporting a model.
-        pcb_material_elasticity: PcbMaterialElasticity
+        pcb_material_type: PcbMaterialType
             The type of PCB material elasticity to use when exporting a model. The default value is
-            ``PcbMaterialElasticity.Isotropic``.
+            ``PcbMaterialType.Isotropic``.
         geometry_type: GeometryType
             The type of geometry to export for WBJN file. The default value is
             ``GeometryType.Step``.
@@ -768,12 +766,12 @@ class Model(GrpcStub):
         Examples
         --------
         >>> from ansys.api.sherlock.v0.SherlockModelService_pb2 import (
-            GeometryType,
-            PcbMaterialElasticity,
-        )
+        >>> GeometryType,
+        >>> PcbMaterialType,
+        >>> )
         >>> from ansys.sherlock.core.types.common_types import (
-            Measurement,
-        )
+        >>> Measurement,
+        >>> )
         >>> from ansys.sherlock.core import launcher
         >>> sherlock, install_dir = launcher.launch_and_connect(transport_mode="wnua")
         >>> sherlock.model.export_FEA_model(
@@ -803,7 +801,7 @@ class Model(GrpcStub):
         >>>     clear_FEA_database=True,
         >>>     use_FEA_model_id=True,
         >>>     coordinate_units="mm",
-        >>>     pcb_material_elasticity=PcbMaterialElasticity.Isotropic,
+        >>>     pcb_material_type=PcbMaterialType.Isotropic,
         >>>     geometry_type=GeometryType.PartManager
         >>> )
         """
@@ -819,7 +817,7 @@ class Model(GrpcStub):
 
             if not os.path.exists(os.path.dirname(export_file)):
                 raise SherlockExportFEAModelError(
-                    message=f"Export file directory " f'"{export_file}" ' f"does not exist."
+                    message=f'Export file directory "{export_file}" does not exist.'
                 )
 
             for param in drill_hole_parameters:
@@ -887,7 +885,7 @@ class Model(GrpcStub):
             export_request.clearFEADatabase = clear_FEA_database
             export_request.useFEAModelID = use_FEA_model_id
             export_request.coordinateUnits = coordinate_units
-            export_request.pcbMaterialElasticity = pcb_material_elasticity
+            export_request.pcbMaterialType = pcb_material_type
             export_request.geometryType = geometry_type
 
             return_code = self.stub.exportFEAModel(export_request)

--- a/src/ansys/sherlock/core/model.py
+++ b/src/ansys/sherlock/core/model.py
@@ -751,7 +751,7 @@ class Model(GrpcStub):
         coordinate_units: str
             Units of the model coordinates to use when exporting a model.
         pcb_material_type: PcbMaterialType
-            The type of PCB material elasticity to use when exporting a model. The default value is
+            The type of PCB material type to use when exporting a model. The default value is
             ``PcbMaterialType.Isotropic``.
         geometry_type: GeometryType
             The type of geometry to export for WBJN file. The default value is

--- a/src/ansys/sherlock/core/types/analysis_types.py
+++ b/src/ansys/sherlock/core/types/analysis_types.py
@@ -378,6 +378,10 @@ class UpdateTraceModelingPropsAnalysis(BaseModel):
     """Whether to enable trace modeling."""
     trace_element_order: analysis_service.ElementOrder.ValueType
     """Trace modeling element order."""
+    trace_max_edge_length: float
+    """Trace max mesh size."""
+    trace_max_edge_length_units: str
+    """Trace max mesh size units."""
     trace_max_holes: int
     """Trace modeling maximum holes per trace."""
 
@@ -388,6 +392,8 @@ class UpdateTraceModelingPropsAnalysis(BaseModel):
         grpc_data.type = self.analysis_type
         grpc_data.traceEnabled = self.trace_enabled
         grpc_data.traceElemOrder = self.trace_element_order
+        grpc_data.traceMaxEdgeLength = self.trace_max_edge_length
+        grpc_data.traceMaxEdgeLengthUnits = self.trace_max_edge_length_units
         grpc_data.traceMaxHoles = self.trace_max_holes
         return grpc_data
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -2254,12 +2254,16 @@ def helper_test_update_trace_modeling_props(analysis: Analysis):
         analysis_type=AnalysisService.UpdateTraceModelingPropsRequest.Analysis.HarmonicVibe,
         trace_enabled=False,
         trace_element_order=AnalysisService.ElementOrder.Linear,
+        trace_max_edge_length=0.1,
+        trace_max_edge_length_units="mm",
         trace_max_holes=10,
     )
     analysis_props2 = UpdateTraceModelingPropsAnalysis(
         analysis_type=AnalysisService.UpdateTraceModelingPropsRequest.Analysis.ICTAnalysis,
         trace_enabled=True,
         trace_element_order=AnalysisService.ElementOrder.Quadratic,
+        trace_max_edge_length=0.2,
+        trace_max_edge_length_units="m",
         trace_max_holes=20,
     )
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -27,7 +27,7 @@ import os
 import platform
 import unittest
 
-from ansys.api.sherlock.v0.SherlockModelService_pb2 import GeometryType, PcbMaterialElasticity
+from ansys.api.sherlock.v0.SherlockModelService_pb2 import GeometryType, PcbMaterialType
 import grpc
 import pytest
 
@@ -339,7 +339,7 @@ class TestModel(unittest.TestCase):
                 clear_FEA_database=True,
                 use_FEA_model_id=True,
                 coordinate_units="mm",
-                pcb_material_elasticity=PcbMaterialElasticity.Isotropic,
+                pcb_material_type=PcbMaterialType.Isotropic,
                 geometry_type=GeometryType.Step,
             )
             pytest.fail("No exception raised for invalid project name")
@@ -374,7 +374,7 @@ class TestModel(unittest.TestCase):
                 clear_FEA_database=True,
                 use_FEA_model_id=True,
                 coordinate_units="mm",
-                pcb_material_elasticity=PcbMaterialElasticity.Isotropic,
+                pcb_material_type=PcbMaterialType.Isotropic,
                 geometry_type=GeometryType.Step,
             )
             pytest.fail("No exception raised for invalid CCA name")
@@ -409,7 +409,7 @@ class TestModel(unittest.TestCase):
                 clear_FEA_database=True,
                 use_FEA_model_id=True,
                 coordinate_units="mm",
-                pcb_material_elasticity=PcbMaterialElasticity.Isotropic,
+                pcb_material_type=PcbMaterialType.Isotropic,
                 geometry_type=GeometryType.Step,
             )
             pytest.fail("No exception raised for invalid file path")
@@ -444,7 +444,7 @@ class TestModel(unittest.TestCase):
                 clear_FEA_database=True,
                 use_FEA_model_id=True,
                 coordinate_units="mm",
-                pcb_material_elasticity=PcbMaterialElasticity.Isotropic,
+                pcb_material_type=PcbMaterialType.Isotropic,
                 geometry_type=GeometryType.Step,
             )
             pytest.fail("No exception raised for invalid file directory")
@@ -479,7 +479,7 @@ class TestModel(unittest.TestCase):
                 clear_FEA_database=True,
                 use_FEA_model_id=True,
                 coordinate_units="mm",
-                pcb_material_elasticity=PcbMaterialElasticity.Isotropic,
+                pcb_material_type=PcbMaterialType.Isotropic,
                 geometry_type=GeometryType.Step,
             )
             pytest.fail("No exception raised for invalid minimum hole diameter")
@@ -514,7 +514,7 @@ class TestModel(unittest.TestCase):
                 clear_FEA_database=True,
                 use_FEA_model_id=True,
                 coordinate_units="mm",
-                pcb_material_elasticity=PcbMaterialElasticity.Isotropic,
+                pcb_material_type=PcbMaterialType.Isotropic,
                 geometry_type=GeometryType.Step,
             )
             pytest.fail("No exception raised for invalid maximum edge length")
@@ -549,7 +549,7 @@ class TestModel(unittest.TestCase):
                 clear_FEA_database=True,
                 use_FEA_model_id=True,
                 coordinate_units="mm",
-                pcb_material_elasticity=PcbMaterialElasticity.Isotropic,
+                pcb_material_type=PcbMaterialType.Isotropic,
                 geometry_type=GeometryType.Step,
             )
             pytest.fail("No exception raised for invalid maximum mesh size")
@@ -584,7 +584,7 @@ class TestModel(unittest.TestCase):
                 clear_FEA_database=True,
                 use_FEA_model_id=True,
                 coordinate_units="mm",
-                pcb_material_elasticity=PcbMaterialElasticity.Isotropic,
+                pcb_material_type=PcbMaterialType.Isotropic,
                 geometry_type=GeometryType.Step,
             )
             pytest.fail("No exception raised for invalid vertical mesh size")
@@ -620,7 +620,7 @@ class TestModel(unittest.TestCase):
                     clear_FEA_database=True,
                     use_FEA_model_id=True,
                     coordinate_units="mm",
-                    pcb_material_elasticity=PcbMaterialElasticity.Isotropic,
+                    pcb_material_type=PcbMaterialType.Isotropic,
                     geometry_type=GeometryType.Step,
                 )
                 pytest.fail("No exception raised for invalid CCA name")
@@ -655,7 +655,7 @@ class TestModel(unittest.TestCase):
                     clear_FEA_database=False,
                     use_FEA_model_id=False,
                     coordinate_units="mm",
-                    pcb_material_elasticity=PcbMaterialElasticity.Isotropic,
+                    pcb_material_type=PcbMaterialType.Isotropic,
                     geometry_type=GeometryType.Step,
                 )
                 assert result == 0


### PR DESCRIPTION
## Description
Add Max Mesh Size fields to the request to update trace modeling properties

## Issue linked
#759 

## Checklist:
- [x] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [x] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [na] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [x] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [ ] Check that test code coverage is at least 80% when Sherlock is running
- [ ] Check vulnerabilities locally
- [x] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
