### PR TITLE
fix: Fixed ListLaminatesResponse and ListConductorLayersResponse

### DIFF
--- a/doc/changelog.d/850.added.md
+++ b/doc/changelog.d/850.added.md
@@ -1,0 +1,1 @@
+Fix: Fixed ListLaminatesResponse and ListConductorLayersResponse

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
 ]
 
 dependencies = [
-    "ansys-api-sherlock==2.0.1",
+    "ansys-api-sherlock==2.0.2",
     "grpcio>=1.80.0",
     "protobuf>=6.33.5,<7", # avoid DoS vulnerability in >= 6.30.0rc1, <= 6.33.4
     "pydantic>=2.9.2",

--- a/tests/test_stackup.py
+++ b/tests/test_stackup.py
@@ -513,12 +513,7 @@ def helper_test_list_conductor_layers(stackup: Stackup):
             layer_properties = layer_properties_per_layer[0]
             assert layer_properties.layer == "1"
             assert layer_properties.type == "SIGNAL"
-            assert (
-                layer_properties.thermalConductivityXY == 10.421635204081632
-            ), "Incorrect thermalConductivityXY value"
-            assert (
-                layer_properties.thermalConductivityZ == 0.36878200673743683
-            ), "Incorrect thermalConductivityZ value"
+            assert layer_properties.layerConductivity == 192.65, "Incorrect layerConductivity value"
         except SherlockListConductorLayersError as e:
             pytest.fail(str(e))
 
@@ -548,11 +543,8 @@ def helper_test_list_laminate_layers(stackup: Stackup):
             layer_properties = layer_properties_per_layer[0]
             assert layer_properties.layer == "2"
             assert (
-                layer_properties.thermalConductivityXY == 10.421635204081632
-            ), "Incorrect thermalConductivityXY value"
-            assert (
-                layer_properties.thermalConductivityZ == 0.36878200673743683
-            ), "Incorrect thermalConductivityZ value"
+                layer_properties.layerConductivity == 0.221847689025
+            ), "Incorrect layerConductivity value"
         except SherlockListLaminateLayersError as e:
             pytest.fail(str(e))
 

--- a/tests/test_stackup.py
+++ b/tests/test_stackup.py
@@ -542,9 +542,7 @@ def helper_test_list_laminate_layers(stackup: Stackup):
             assert len(layer_properties_per_layer) == 5, "Incorrect number of laminate layers"
             layer_properties = layer_properties_per_layer[0]
             assert layer_properties.layer == "2"
-            assert (
-                layer_properties.layerConductivity == 0.221847689025
-            ), "Incorrect layerConductivity value"
+            assert layer_properties.layerConductivity == 0.35, "Incorrect layerConductivity value"
         except SherlockListLaminateLayersError as e:
             pytest.fail(str(e))
 


### PR DESCRIPTION
## Description
The thermalConductivityXYZ property was replaced with layerConductivity

## Issue linked
#817 

## Checklist:
- [x] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [x] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [ ] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [x] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [x] Check that test code coverage is at least 80% when Sherlock is running
- [x] Check vulnerabilities locally
- [x] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
