### PR TITLE
build: Update Python version support from 3.10 to 3.12 in CI/CD and documentation

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -52,7 +52,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ ubuntu-latest, windows-latest, macos-latest ]
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.12', '3.13', '3.14' ]
         should-release:
           - ${{ github.event_name == 'push' && contains(github.ref, 'refs/tags') }}
         exclude:
@@ -73,7 +73,7 @@ jobs:
     runs-on: [ self-hosted, pysherlock ]
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
+        python-version: [ '3.12', '3.13', '3.14' ]
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.script/test_version_automation.py
+++ b/.script/test_version_automation.py
@@ -48,7 +48,7 @@ name = "ansys-sherlock-core"
 version = "{version}"
 description = "A Python wrapper for Ansys Sherlock"
 readme = "README.rst"
-requires-python = ">=3.10,<4"
+requires-python = ">=3.12,<4"
 license = {{file = "LICENSE"}}
 
 [project.urls]

--- a/doc/changelog.d/888.documentation.md
+++ b/doc/changelog.d/888.documentation.md
@@ -1,0 +1,1 @@
+Build: Update Python version support from 3.10 to 3.12 in CI/CD and documentation

--- a/doc/source/contributing.rst
+++ b/doc/source/contributing.rst
@@ -171,17 +171,17 @@ archive from the `Releases Page <https://github.com/ansys/pysherlock/releases>`_
 corresponding machine architecture.
 
 Each wheelhouse archive contains all the Python wheels necessary to install PySherlock from scratch on Windows,
-Linux, and MacOS from Python 3.10 to 3.14. You can install this on an isolated system with a fresh Python
+Linux, and MacOS from Python 3.12 to 3.14. You can install this on an isolated system with a fresh Python
 installation or on a virtual environment.
 
-For example, on Linux with Python 3.10, unzip the wheelhouse archive and install it with:
+For example, on Linux with Python 3.12, unzip the wheelhouse archive and install it with:
 
 .. code:: bash
 
-    unzip ansys-sherlock-core-v0.3.dev0-wheelhouse-Linux-3.10.zip wheelhouse
+    unzip ansys-sherlock-core-v0.3.dev0-wheelhouse-Linux-3.12.zip wheelhouse
     pip install ansys-sherlock-core -f wheelhouse --no-index --upgrade --ignore-installed
 
-If you're on Windows with Python 3.10, unzip to a wheelhouse directory and install using the preceding command.
+If you're on Windows with Python 3.12, unzip to a wheelhouse directory and install using the preceding command.
 
 Consider installing using a `virtual environment <https://docs.python.org/3/library/venv.html>`_.
 

--- a/doc/source/getting_started/installation.rst
+++ b/doc/source/getting_started/installation.rst
@@ -4,7 +4,7 @@
 Install packages
 ================
 
-The ``ansys-sherlock-core`` package supports Python 3.10 through Python 3.14 on Windows and Linux.
+The ``ansys-sherlock-core`` package supports Python 3.12 through Python 3.14 on Windows and Linux.
 
 To use PySherlock, you must download and install both the ``ansys-api-sherlock``
 and ``ansys-sherlock-core`` packages. By using ``pip``, ``ansys-api-sherlock`` is

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "ansys-sherlock-core"
 version = "1.0.dev0"
 description = "A python wrapper for Ansys Sherlock"
 readme = "README.rst"
-requires-python = ">=3.10,<4"
+requires-python = ">=3.12,<4"
 license = "MIT"
 license-files = ["LICENSE"]
 authors = [{name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"}]
@@ -17,8 +17,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Topic :: Scientific/Engineering :: Information Analysis",
     "Operating System :: OS Independent",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: 3.14",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 description = Default tox environments list
 envlist =
-    style,{py310,py311,py312,py313}{,-coverage},doc
+    style,{py312,py313,py314}{,-coverage},doc
 skip_missing_interpreters = true
 isolated_build = true
 isolated_build_env = build
@@ -9,10 +9,9 @@ isolated_build_env = build
 [testenv]
 description = Checks for project unit tests and coverage (if desired)
 basepython =
-    py310: python3.10
-    py311: python3.11
-    py311: python3.12
-    py311: python3.13
+    py312: python3.12
+    py313: python3.13
+    py314: python3.14
     py: python3
     {style,reformat,doc}: python3
 setenv =


### PR DESCRIPTION


**Python Version Support Update:**

* Updated the supported Python versions in the CI/CD workflow matrix to include only Python 3.12, 3.13, and 3.14, removing 3.10 and 3.11 (`.github/workflows/ci_cd.yml`). [[1]](diffhunk://#diff-c80d54cb778b5196ee7b73e152870cac313eed095f65886e3f15247cdc900d1aL55-R55) [[2]](diffhunk://#diff-c80d54cb778b5196ee7b73e152870cac313eed095f65886e3f15247cdc900d1aL76-R76)
* Changed the `requires-python` field in both `pyproject.toml` and the test automation script to require Python >=3.12,<4. [[1]](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L10-R10) [[2]](diffhunk://#diff-6072dc7ae5018687983b520805bd0a3a7458834cc259d704b5394d83f90bc49fL51-R51)
* Removed Python 3.10 and 3.11 from the `tox.ini` environments and basepython configuration.
* Updated the PyPI classifiers in `pyproject.toml` to remove Python 3.10 and 3.11, reflecting support for 3.12, 3.13, and 3.14 only.

**Documentation Updates:**

* Revised documentation to state support for Python 3.12–3.14, including installation guides, changelog, and contributing instructions. [[1]](diffhunk://#diff-0f9f570afdb86a5b52d8b15f866bd9a3c1eefb3993bc406937144cce52c262f6R1) [[2]](diffhunk://#diff-82775b63a9f4f88a91d2a436475cf9352dc3f02ffcb5cdf6e81e62013aa34b0dL174-R184) [[3]](diffhunk://#diff-b9f3d061d09371bdfa76ce4837702e10bfdb4ccd383a03d4ce6afebafa10f67aL7-R7)
