### PR TITLE
chore: Deprecated Enum wrappers

### DIFF
--- a/doc/changelog.d/940.added.md
+++ b/doc/changelog.d/940.added.md
@@ -1,0 +1,1 @@
+Chore: Deprecated Enum wrappers

--- a/doc/source/user_guide/index.rst
+++ b/doc/source/user_guide/index.rst
@@ -80,12 +80,14 @@ This code uses the Sherlock Part Library to update the parts list:
 
 .. code::
 
+    from ansys.api.sherlock.v0 import SherlockCommonService_pb2, SherlockPartsService_pb2
+
     sherlock.parts.update_parts_list(
         "Tutorial",
         "Main Board",
         "Sherlock Part Library",
-        "Both",
-        PartsListSearchDuplicationMode.ERROR,
+        SherlockCommonService_pb2.MatchingMode.Both,
+        SherlockPartsService_pb2.DuplicationMode.Error,
     )
 
 For information on the ``parts`` module and its methods, see :ref:`ref_parts_module`.
@@ -140,16 +142,17 @@ to run a random vibe analysis:
 
 .. code::
 
+    from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
+
     sherlock.analysis.run_analysis(
         "Tutorial",
         "Main Board",
         [
-            (RunAnalysisRequestAnalysisType.RANDOM_VIBE,
-            [
-                ("Phase 1", ["RVEvent 1"])
-            ]
+            (
+                SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.RandomVibe,
+                [("Phase 1", ["RVEvent 1"])],
             )
-        ]
+        ],
     )
 
 For information on the ``analysis`` module and its methods, see :ref:`ref_analysis_module`.

--- a/examples/01-project-configuration/update_parts_list.py
+++ b/examples/01-project-configuration/update_parts_list.py
@@ -44,8 +44,7 @@ The updated parts list ensures alignment with a specified library for consistenc
 
 import os
 
-import SherlockCommonService_pb2
-import SherlockPartsService_pb2
+from ansys.api.sherlock.v0 import SherlockCommonService_pb2, SherlockPartsService_pb2
 from examples.examples_globals import get_sherlock_tutorial_path
 
 from ansys.sherlock.core import launcher

--- a/examples/04-analyses/run_analysis.py
+++ b/examples/04-analyses/run_analysis.py
@@ -44,12 +44,12 @@ import os
 
 from examples.examples_globals import get_sherlock_tutorial_path
 
+from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.sherlock.core import launcher
 from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,
     SherlockRunAnalysisError,
 )
-from ansys.sherlock.core.types.analysis_types import RunAnalysisRequestAnalysisType
 
 ###############################################################################
 # Connect to Sherlock
@@ -93,14 +93,20 @@ try:
     # Run analyses
 
     analysis_types = [
-        (RunAnalysisRequestAnalysisType.PTH_FATIQUE, [("Phase 1", ["Thermal Event"])]),
         (
-            RunAnalysisRequestAnalysisType.SEMICINDUCTOR_WEAROUT,
+            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.PTHFatigue,
             [("Phase 1", ["Thermal Event"])],
         ),
-        (RunAnalysisRequestAnalysisType.THERMAL_DERATING, [("Phase 1", ["Thermal Event"])]),
         (
-            RunAnalysisRequestAnalysisType.COMPONENT_FAILURE_MODE,
+            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.SemiconductorWearout,
+            [("Phase 1", ["Thermal Event"])],
+        ),
+        (
+            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ThermalDerating,
+            [("Phase 1", ["Thermal Event"])],
+        ),
+        (
+            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ComponentFailureMode,
             [("Phase 1", ["Thermal Event"])],
         ),
     ]

--- a/examples/04-analyses/run_analysis.py
+++ b/examples/04-analyses/run_analysis.py
@@ -45,7 +45,6 @@ import os
 from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from examples.examples_globals import get_sherlock_tutorial_path
 
-from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.sherlock.core import launcher
 from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,
@@ -104,22 +103,10 @@ try:
     )
 
     analysis_types = [
-        (
-            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.PTHFatigue,
-            [("Phase 1", ["Thermal Event"])],
-        ),
-        (
-            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.SemiconductorWearout,
-            [("Phase 1", ["Thermal Event"])],
-        ),
-        (
-            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ThermalDerating,
-            [("Phase 1", ["Thermal Event"])],
-        ),
-        (
-            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ComponentFailureMode,
-            [("Phase 1", ["Thermal Event"])],
-        ),
+        (pth_fatigue, [("Phase 1", ["Thermal Event"])]),
+        (semiconductor_wearout, [("Phase 1", ["Thermal Event"])]),
+        (thermal_derating, [("Phase 1", ["Thermal Event"])]),
+        (component_failure_mode, [("Phase 1", ["Thermal Event"])]),
     ]
 
     for analysis_type, params in analysis_types:

--- a/examples/04-analyses/run_analysis.py
+++ b/examples/04-analyses/run_analysis.py
@@ -42,9 +42,9 @@ and others.
 
 import os
 
+from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from examples.examples_globals import get_sherlock_tutorial_path
 
-from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.sherlock.core import launcher
 from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,
@@ -91,24 +91,22 @@ except SherlockImportProjectZipArchiveError as e:
 
 try:
     # Run analyses
+    pth_fatigue = SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.PTHFatigue
+    semiconductor_wearout = (
+        SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.SemiconductorWearout
+    )
+    thermal_derating = (
+        SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ThermalDerating
+    )
+    component_failure_mode = (
+        SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ComponentFailureMode
+    )
 
     analysis_types = [
-        (
-            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.PTHFatigue,
-            [("Phase 1", ["Thermal Event"])],
-        ),
-        (
-            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.SemiconductorWearout,
-            [("Phase 1", ["Thermal Event"])],
-        ),
-        (
-            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ThermalDerating,
-            [("Phase 1", ["Thermal Event"])],
-        ),
-        (
-            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ComponentFailureMode,
-            [("Phase 1", ["Thermal Event"])],
-        ),
+        (pth_fatigue, [("Phase 1", ["Thermal Event"])]),
+        (semiconductor_wearout, [("Phase 1", ["Thermal Event"])]),
+        (thermal_derating, [("Phase 1", ["Thermal Event"])]),
+        (component_failure_mode, [("Phase 1", ["Thermal Event"])]),
     ]
 
     for analysis_type, params in analysis_types:

--- a/examples/04-analyses/run_analysis.py
+++ b/examples/04-analyses/run_analysis.py
@@ -45,6 +45,7 @@ import os
 from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from examples.examples_globals import get_sherlock_tutorial_path
 
+from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.sherlock.core import launcher
 from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,
@@ -103,10 +104,22 @@ try:
     )
 
     analysis_types = [
-        (pth_fatigue, [("Phase 1", ["Thermal Event"])]),
-        (semiconductor_wearout, [("Phase 1", ["Thermal Event"])]),
-        (thermal_derating, [("Phase 1", ["Thermal Event"])]),
-        (component_failure_mode, [("Phase 1", ["Thermal Event"])]),
+        (
+            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.PTHFatigue,
+            [("Phase 1", ["Thermal Event"])],
+        ),
+        (
+            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.SemiconductorWearout,
+            [("Phase 1", ["Thermal Event"])],
+        ),
+        (
+            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ThermalDerating,
+            [("Phase 1", ["Thermal Event"])],
+        ),
+        (
+            SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ComponentFailureMode,
+            [("Phase 1", ["Thermal Event"])],
+        ),
     ]
 
     for analysis_type, params in analysis_types:

--- a/examples/04-analyses/run_harmonic_vibe_strain_map_analysis.py
+++ b/examples/04-analyses/run_harmonic_vibe_strain_map_analysis.py
@@ -45,6 +45,7 @@ For further details, refer to the official documentation on strain map analysis 
 
 import os
 
+from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.api.sherlock.v0.SherlockAnalysisService_pb2 import RunStrainMapAnalysisRequest
 from examples.examples_globals import get_sherlock_tutorial_path
 
@@ -55,7 +56,6 @@ from ansys.sherlock.core.errors import (
     SherlockRunStrainMapAnalysisError,
     SherlockUpdateHarmonicVibePropsError,
 )
-from ansys.sherlock.core.types.analysis_types import ModelSource
 from ansys.sherlock.core.types.project_types import StrainMapsFileType
 
 ###############################################################################
@@ -129,7 +129,7 @@ try:
         harmonic_vibe_properties=[
             {
                 "cca_name": "Main Board",
-                "model_source": ModelSource.STRAIN_MAP,
+                "model_source": SherlockAnalysisService_pb2.ModelSource.STRAIN_MAP,
                 "harmonic_vibe_count": 1,
                 "harmonic_vibe_damping": "0.01",
                 "part_validation_enabled": False,

--- a/examples/04-analyses/run_mechanical_shock_strain_map_analysis.py
+++ b/examples/04-analyses/run_mechanical_shock_strain_map_analysis.py
@@ -44,6 +44,7 @@ For further details, refer to the official documentation on mechanical shock ana
 
 import os
 
+from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.api.sherlock.v0.SherlockAnalysisService_pb2 import RunStrainMapAnalysisRequest
 from examples.examples_globals import get_sherlock_tutorial_path
 
@@ -53,7 +54,6 @@ from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,
     SherlockRunStrainMapAnalysisError,
 )
-from ansys.sherlock.core.types.analysis_types import ModelSource
 from ansys.sherlock.core.types.project_types import StrainMapsFileType
 
 ###############################################################################
@@ -127,7 +127,7 @@ try:
         mechanical_shock_properties=[
             {
                 "cca_name": "Main Board",
-                "model_source": ModelSource.STRAIN_MAP,
+                "model_source": SherlockAnalysisService_pb2.ModelSource.STRAIN_MAP,
                 "shock_result_count": 1,
                 "part_validation_enabled": False,
                 "require_material_assignment_enabled": True,

--- a/examples/04-analyses/run_random_vibe_strain_map_analysis.py
+++ b/examples/04-analyses/run_random_vibe_strain_map_analysis.py
@@ -145,9 +145,10 @@ except SherlockRunStrainMapAnalysisError as e:
 
 try:
     analysis_request = SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest
-    random_vibe = (
-        SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe  # noqa: E501
+    strain_map_analysis_type = (
+        SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType
     )
+    random_vibe = strain_map_analysis_type.RandomVibe
     sherlock.analysis.run_strain_map_analysis(
         project="Test",
         cca_name="Main Board",

--- a/examples/04-analyses/run_random_vibe_strain_map_analysis.py
+++ b/examples/04-analyses/run_random_vibe_strain_map_analysis.py
@@ -153,7 +153,7 @@ try:
         cca_name="Main Board",
         strain_map_analyses=[
             [
-                SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                random_vibe,
                 [
                     ["On The Road", "1 - Vibration", "TOP", "StrainMap - Top"],
                     ["On The Road", "1 - Vibration", "BOTTOM", "StrainMap - Bottom"],

--- a/examples/04-analyses/run_random_vibe_strain_map_analysis.py
+++ b/examples/04-analyses/run_random_vibe_strain_map_analysis.py
@@ -51,10 +51,6 @@ from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,
     SherlockRunStrainMapAnalysisError,
 )
-from ansys.sherlock.core.types.analysis_types import (
-    ModelSource,
-    RunStrainMapAnalysisRequestAnalysisType,
-)
 from ansys.sherlock.core.types.project_types import StrainMapsFileType
 
 ###############################################################################
@@ -125,7 +121,7 @@ try:
     sherlock.analysis.update_random_vibe_props(
         project="Test",
         cca_name="Main Board",
-        model_source=ModelSource.STRAIN_MAP,
+        model_source=SherlockAnalysisService_pb2.ModelSource.STRAIN_MAP,
         random_vibe_damping="0.01",
         part_validation_enabled=False,
         require_material_assignment_enabled=True,
@@ -154,7 +150,7 @@ try:
         cca_name="Main Board",
         strain_map_analyses=[
             [
-                RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                 [
                     ["On The Road", "1 - Vibration", "TOP", "StrainMap - Top"],
                     ["On The Road", "1 - Vibration", "BOTTOM", "StrainMap - Bottom"],

--- a/examples/04-analyses/run_random_vibe_strain_map_analysis.py
+++ b/examples/04-analyses/run_random_vibe_strain_map_analysis.py
@@ -145,12 +145,15 @@ except SherlockRunStrainMapAnalysisError as e:
 
 try:
     analysis_request = SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest
+    random_vibe = (
+        SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe  # noqa: E501
+    )
     sherlock.analysis.run_strain_map_analysis(
         project="Test",
         cca_name="Main Board",
         strain_map_analyses=[
             [
-                SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                random_vibe,
                 [
                     ["On The Road", "1 - Vibration", "TOP", "StrainMap - Top"],
                     ["On The Road", "1 - Vibration", "BOTTOM", "StrainMap - Bottom"],

--- a/examples/04-analyses/run_random_vibe_strain_map_analysis.py
+++ b/examples/04-analyses/run_random_vibe_strain_map_analysis.py
@@ -153,7 +153,7 @@ try:
         cca_name="Main Board",
         strain_map_analyses=[
             [
-                random_vibe,
+                SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                 [
                     ["On The Road", "1 - Vibration", "TOP", "StrainMap - Top"],
                     ["On The Road", "1 - Vibration", "BOTTOM", "StrainMap - Bottom"],

--- a/examples/04-analyses/update_mechanical_shock_properties.py
+++ b/examples/04-analyses/update_mechanical_shock_properties.py
@@ -45,12 +45,12 @@ import os
 
 from examples.examples_globals import get_sherlock_tutorial_path
 
+from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.sherlock.core import launcher
 from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,
     SherlockUpdateMechanicalShockPropsError,
 )
-from ansys.sherlock.core.types.analysis_types import ModelSource
 
 ###############################################################################
 # Connect to Sherlock
@@ -97,7 +97,7 @@ try:
         mechanical_shock_properties=[
             {
                 "cca_name": "Auto Relay",
-                "model_source": ModelSource.GENERATED,
+                "model_source": SherlockAnalysisService_pb2.ModelSource.GENERATED,
                 "shock_result_count": 3,
                 "critical_shock_strain": 5,
                 "critical_shock_strain_units": "strain",

--- a/examples/04-analyses/update_mechanical_shock_properties.py
+++ b/examples/04-analyses/update_mechanical_shock_properties.py
@@ -46,6 +46,7 @@ import os
 from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from examples.examples_globals import get_sherlock_tutorial_path
 
+from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.sherlock.core import launcher
 from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,

--- a/examples/04-analyses/update_mechanical_shock_properties.py
+++ b/examples/04-analyses/update_mechanical_shock_properties.py
@@ -46,7 +46,6 @@ import os
 from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from examples.examples_globals import get_sherlock_tutorial_path
 
-from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.sherlock.core import launcher
 from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,

--- a/examples/04-analyses/update_mechanical_shock_properties.py
+++ b/examples/04-analyses/update_mechanical_shock_properties.py
@@ -43,9 +43,9 @@ sphinx_gallery_thumbnail_path =
 
 import os
 
+from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from examples.examples_globals import get_sherlock_tutorial_path
 
-from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.sherlock.core import launcher
 from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,

--- a/examples/04-analyses/update_pcb_modeling_properties.py
+++ b/examples/04-analyses/update_pcb_modeling_properties.py
@@ -40,9 +40,9 @@ This script performs the following steps:
 
 import os
 
+from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from examples.examples_globals import get_sherlock_tutorial_path
 
-from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.sherlock.core import launcher
 from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,
@@ -88,89 +88,72 @@ except SherlockImportProjectZipArchiveError as e:
 # Configure PCB modeling properties for various analysis types.
 
 try:
+    harmonic_vibe = (
+        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.HarmonicVibe
+    )
+    natural_freq = (
+        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq
+    )
+    ict_analysis = (
+        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ICTAnalysis
+    )
+    mechanical_shock = (
+        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.MechanicalShock  # noqa: E501
+    )
+    random_vibe = (
+        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.RandomVibe
+    )
+    thermal_mech = (
+        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ThermalMech
+    )
+    bonded = (
+        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded
+    )  # noqa: E501
+    uniform = (
+        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform  # noqa: E501
+    )
+    layered = (
+        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered  # noqa: E501
+    )
+    layered_elements = (
+        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.LayeredElements  # noqa: E501
+    )
+    uniform_elements = (
+        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.UniformElements  # noqa: E501
+    )
+    solid_shell = SherlockAnalysisService_pb2.ElementOrder.SolidShell
+
     sherlock.analysis.update_pcb_modeling_props(
         project="Test",
         cca_names=["Auto Relay"],
-        analyses=[
-            (
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.HarmonicVibe,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                True,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
-                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
-                6,
-                "mm",
-                3,
-                "mm",
-                True,
-            )
-        ],
+        analyses=[(harmonic_vibe, bonded, True, uniform, solid_shell, 6, "mm", 3, "mm", True)],
+    )
+    sherlock.analysis.update_pcb_modeling_props(
+        project="Test",
+        cca_names=["Auto Relay"],
+        analyses=[(natural_freq, bonded, True, uniform, solid_shell, 6, "mm", 3, "mm", True)],
+    )
+    sherlock.analysis.update_pcb_modeling_props(
+        project="Test",
+        cca_names=["Auto Relay"],
+        analyses=[(ict_analysis, bonded, True, uniform, solid_shell, 6, "mm", 3, "mm", True)],
+    )
+    sherlock.analysis.update_pcb_modeling_props(
+        project="Test",
+        cca_names=["Auto Relay"],
+        analyses=[(mechanical_shock, bonded, True, layered, solid_shell, 6, "mm", 3, "mm", True)],
     )
     sherlock.analysis.update_pcb_modeling_props(
         project="Test",
         cca_names=["Auto Relay"],
         analyses=[
             (
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                random_vibe,
+                bonded,
                 True,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
-                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
-                6,
-                "mm",
-                3,
-                "mm",
-                True,
-            )
-        ],
-    )
-    sherlock.analysis.update_pcb_modeling_props(
-        project="Test",
-        cca_names=["Auto Relay"],
-        analyses=[
-            (
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ICTAnalysis,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                True,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
-                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
-                6,
-                "mm",
-                3,
-                "mm",
-                True,
-            )
-        ],
-    )
-    sherlock.analysis.update_pcb_modeling_props(
-        project="Test",
-        cca_names=["Auto Relay"],
-        analyses=[
-            (
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.MechanicalShock,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                True,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered,
-                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
-                6,
-                "mm",
-                3,
-                "mm",
-                True,
-            )
-        ],
-    )
-    sherlock.analysis.update_pcb_modeling_props(
-        project="Test",
-        cca_names=["Auto Relay"],
-        analyses=[
-            (
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.RandomVibe,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                True,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.LayeredElements,
+                layered_elements,
                 5,
-                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
+                solid_shell,
                 6,
                 "mm",
                 3,
@@ -184,12 +167,12 @@ try:
         cca_names=["Auto Relay"],
         analyses=[
             (
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ThermalMech,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                thermal_mech,
+                bonded,
                 True,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.UniformElements,
+                uniform_elements,
                 5,
-                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
+                solid_shell,
                 6,
                 "mm",
                 3,

--- a/examples/04-analyses/update_pcb_modeling_properties.py
+++ b/examples/04-analyses/update_pcb_modeling_properties.py
@@ -43,7 +43,6 @@ import os
 from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from examples.examples_globals import get_sherlock_tutorial_path
 
-from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.sherlock.core import launcher
 from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,
@@ -127,86 +126,34 @@ try:
     sherlock.analysis.update_pcb_modeling_props(
         project="Test",
         cca_names=["Auto Relay"],
-        analyses=[
-            (
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.HarmonicVibe,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                True,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
-                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
-                6,
-                "mm",
-                3,
-                "mm",
-                True,
-            )
-        ],
+        analyses=[(harmonic_vibe, bonded, True, uniform, solid_shell, 6, "mm", 3, "mm", True)],
+    )
+    sherlock.analysis.update_pcb_modeling_props(
+        project="Test",
+        cca_names=["Auto Relay"],
+        analyses=[(natural_freq, bonded, True, uniform, solid_shell, 6, "mm", 3, "mm", True)],
+    )
+    sherlock.analysis.update_pcb_modeling_props(
+        project="Test",
+        cca_names=["Auto Relay"],
+        analyses=[(ict_analysis, bonded, True, uniform, solid_shell, 6, "mm", 3, "mm", True)],
+    )
+    sherlock.analysis.update_pcb_modeling_props(
+        project="Test",
+        cca_names=["Auto Relay"],
+        analyses=[(mechanical_shock, bonded, True, layered, solid_shell, 6, "mm", 3, "mm", True)],
     )
     sherlock.analysis.update_pcb_modeling_props(
         project="Test",
         cca_names=["Auto Relay"],
         analyses=[
             (
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                random_vibe,
+                bonded,
                 True,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
-                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
-                6,
-                "mm",
-                3,
-                "mm",
-                True,
-            )
-        ],
-    )
-    sherlock.analysis.update_pcb_modeling_props(
-        project="Test",
-        cca_names=["Auto Relay"],
-        analyses=[
-            (
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ICTAnalysis,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                True,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
-                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
-                6,
-                "mm",
-                3,
-                "mm",
-                True,
-            )
-        ],
-    )
-    sherlock.analysis.update_pcb_modeling_props(
-        project="Test",
-        cca_names=["Auto Relay"],
-        analyses=[
-            (
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.MechanicalShock,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                True,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered,
-                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
-                6,
-                "mm",
-                3,
-                "mm",
-                True,
-            )
-        ],
-    )
-    sherlock.analysis.update_pcb_modeling_props(
-        project="Test",
-        cca_names=["Auto Relay"],
-        analyses=[
-            (
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.RandomVibe,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                True,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.LayeredElements,
+                layered_elements,
                 5,
-                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
+                solid_shell,
                 6,
                 "mm",
                 3,
@@ -220,12 +167,12 @@ try:
         cca_names=["Auto Relay"],
         analyses=[
             (
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ThermalMech,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                thermal_mech,
+                bonded,
                 True,
-                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.UniformElements,
+                uniform_elements,
                 5,
-                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
+                solid_shell,
                 6,
                 "mm",
                 3,

--- a/examples/04-analyses/update_pcb_modeling_properties.py
+++ b/examples/04-analyses/update_pcb_modeling_properties.py
@@ -43,6 +43,7 @@ import os
 from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from examples.examples_globals import get_sherlock_tutorial_path
 
+from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.sherlock.core import launcher
 from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,
@@ -126,34 +127,13 @@ try:
     sherlock.analysis.update_pcb_modeling_props(
         project="Test",
         cca_names=["Auto Relay"],
-        analyses=[(harmonic_vibe, bonded, True, uniform, solid_shell, 6, "mm", 3, "mm", True)],
-    )
-    sherlock.analysis.update_pcb_modeling_props(
-        project="Test",
-        cca_names=["Auto Relay"],
-        analyses=[(natural_freq, bonded, True, uniform, solid_shell, 6, "mm", 3, "mm", True)],
-    )
-    sherlock.analysis.update_pcb_modeling_props(
-        project="Test",
-        cca_names=["Auto Relay"],
-        analyses=[(ict_analysis, bonded, True, uniform, solid_shell, 6, "mm", 3, "mm", True)],
-    )
-    sherlock.analysis.update_pcb_modeling_props(
-        project="Test",
-        cca_names=["Auto Relay"],
-        analyses=[(mechanical_shock, bonded, True, layered, solid_shell, 6, "mm", 3, "mm", True)],
-    )
-    sherlock.analysis.update_pcb_modeling_props(
-        project="Test",
-        cca_names=["Auto Relay"],
         analyses=[
             (
-                random_vibe,
-                bonded,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.HarmonicVibe,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                 True,
-                layered_elements,
-                5,
-                solid_shell,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
                 6,
                 "mm",
                 3,
@@ -167,12 +147,85 @@ try:
         cca_names=["Auto Relay"],
         analyses=[
             (
-                thermal_mech,
-                bonded,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                 True,
-                uniform_elements,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
+                6,
+                "mm",
+                3,
+                "mm",
+                True,
+            )
+        ],
+    )
+    sherlock.analysis.update_pcb_modeling_props(
+        project="Test",
+        cca_names=["Auto Relay"],
+        analyses=[
+            (
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ICTAnalysis,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                True,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
+                6,
+                "mm",
+                3,
+                "mm",
+                True,
+            )
+        ],
+    )
+    sherlock.analysis.update_pcb_modeling_props(
+        project="Test",
+        cca_names=["Auto Relay"],
+        analyses=[
+            (
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.MechanicalShock,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                True,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered,
+                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
+                6,
+                "mm",
+                3,
+                "mm",
+                True,
+            )
+        ],
+    )
+    sherlock.analysis.update_pcb_modeling_props(
+        project="Test",
+        cca_names=["Auto Relay"],
+        analyses=[
+            (
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.RandomVibe,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                True,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.LayeredElements,
                 5,
-                solid_shell,
+                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
+                6,
+                "mm",
+                3,
+                "mm",
+                True,
+            )
+        ],
+    )
+    sherlock.analysis.update_pcb_modeling_props(
+        project="Test",
+        cca_names=["Auto Relay"],
+        analyses=[
+            (
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ThermalMech,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                True,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.UniformElements,
+                5,
+                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
                 6,
                 "mm",
                 3,

--- a/examples/04-analyses/update_pcb_modeling_properties.py
+++ b/examples/04-analyses/update_pcb_modeling_properties.py
@@ -42,16 +42,11 @@ import os
 
 from examples.examples_globals import get_sherlock_tutorial_path
 
+from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
 from ansys.sherlock.core import launcher
 from ansys.sherlock.core.errors import (
     SherlockImportProjectZipArchiveError,
     SherlockUpdatePcbModelingPropsError,
-)
-from ansys.sherlock.core.types.analysis_types import (
-    ElementOrder,
-    UpdatePcbModelingPropsRequestAnalysisType,
-    UpdatePcbModelingPropsRequestPcbMaterialModel,
-    UpdatePcbModelingPropsRequestPcbModelType,
 )
 
 ###############################################################################
@@ -98,11 +93,11 @@ try:
         cca_names=["Auto Relay"],
         analyses=[
             (
-                UpdatePcbModelingPropsRequestAnalysisType.HARMONIC_VIBE,
-                UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.HarmonicVibe,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                 True,
-                UpdatePcbModelingPropsRequestPcbMaterialModel.UNIFORM,
-                ElementOrder.SOLID_SHELL,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
                 6,
                 "mm",
                 3,
@@ -116,11 +111,11 @@ try:
         cca_names=["Auto Relay"],
         analyses=[
             (
-                UpdatePcbModelingPropsRequestAnalysisType.NATURAL_FREQUENCY,
-                UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                 True,
-                UpdatePcbModelingPropsRequestPcbMaterialModel.UNIFORM,
-                ElementOrder.SOLID_SHELL,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
                 6,
                 "mm",
                 3,
@@ -134,11 +129,11 @@ try:
         cca_names=["Auto Relay"],
         analyses=[
             (
-                UpdatePcbModelingPropsRequestAnalysisType.ICT,
-                UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ICTAnalysis,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                 True,
-                UpdatePcbModelingPropsRequestPcbMaterialModel.UNIFORM,
-                ElementOrder.SOLID_SHELL,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
                 6,
                 "mm",
                 3,
@@ -152,11 +147,11 @@ try:
         cca_names=["Auto Relay"],
         analyses=[
             (
-                UpdatePcbModelingPropsRequestAnalysisType.MECHANICAL_SHOCK,
-                UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.MechanicalShock,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                 True,
-                UpdatePcbModelingPropsRequestPcbMaterialModel.LAYERED,
-                ElementOrder.SOLID_SHELL,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered,
+                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
                 6,
                 "mm",
                 3,
@@ -170,12 +165,12 @@ try:
         cca_names=["Auto Relay"],
         analyses=[
             (
-                UpdatePcbModelingPropsRequestAnalysisType.RANDOM_VIBE,
-                UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.RandomVibe,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                 True,
-                UpdatePcbModelingPropsRequestPcbMaterialModel.LAYERED_ELEMENTS,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.LayeredElements,
                 5,
-                ElementOrder.SOLID_SHELL,
+                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
                 6,
                 "mm",
                 3,
@@ -189,12 +184,12 @@ try:
         cca_names=["Auto Relay"],
         analyses=[
             (
-                UpdatePcbModelingPropsRequestAnalysisType.THERMAL_MECH,
-                UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ThermalMech,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                 True,
-                UpdatePcbModelingPropsRequestPcbMaterialModel.UNIFORM_ELEMENTS,
+                SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.UniformElements,
                 5,
-                ElementOrder.SOLID_SHELL,
+                SherlockAnalysisService_pb2.ElementOrder.SolidShell,
                 6,
                 "mm",
                 3,

--- a/examples/04-analyses/update_pcb_modeling_properties.py
+++ b/examples/04-analyses/update_pcb_modeling_properties.py
@@ -49,6 +49,16 @@ from ansys.sherlock.core.errors import (
     SherlockUpdatePcbModelingPropsError,
 )
 
+PcbAnalysisType = (
+    SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType
+)
+PcbModelType = (
+    SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType
+)
+PcbMaterialModel = (
+    SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType
+)
+
 ###############################################################################
 # Connect to Sherlock
 # ===================
@@ -88,39 +98,23 @@ except SherlockImportProjectZipArchiveError as e:
 # Configure PCB modeling properties for various analysis types.
 
 try:
-    harmonic_vibe = (
-        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.HarmonicVibe
+    analysis_type = SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType
+    material_model = (
+        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel
     )
-    natural_freq = (
-        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq
-    )
-    ict_analysis = (
-        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ICTAnalysis
-    )
-    mechanical_shock = (
-        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.MechanicalShock  # noqa: E501
-    )
-    random_vibe = (
-        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.RandomVibe
-    )
-    thermal_mech = (
-        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ThermalMech
-    )
-    bonded = (
-        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded
-    )  # noqa: E501
-    uniform = (
-        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform  # noqa: E501
-    )
-    layered = (
-        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered  # noqa: E501
-    )
-    layered_elements = (
-        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.LayeredElements  # noqa: E501
-    )
-    uniform_elements = (
-        SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.UniformElements  # noqa: E501
-    )
+    pcb_model_type = SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType
+
+    harmonic_vibe = analysis_type.HarmonicVibe
+    natural_freq = analysis_type.NaturalFreq
+    ict_analysis = analysis_type.ICTAnalysis
+    mechanical_shock = analysis_type.MechanicalShock
+    random_vibe = analysis_type.RandomVibe
+    thermal_mech = analysis_type.ThermalMech
+    bonded = pcb_model_type.Bonded
+    uniform = material_model.Uniform
+    layered = material_model.Layered
+    layered_elements = material_model.LayeredElements
+    uniform_elements = material_model.UniformElements
     solid_shell = SherlockAnalysisService_pb2.ElementOrder.SolidShell
 
     sherlock.analysis.update_pcb_modeling_props(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "flit_core.buildapi"
 
 [project]
 name = "ansys-sherlock-core"
-version = "2.0.dev1"
+version = "2.1.dev0"
 description = "A python wrapper for Ansys Sherlock"
 readme = "README.rst"
 requires-python = ">=3.12,<4"

--- a/src/ansys/sherlock/core/analysis.py
+++ b/src/ansys/sherlock/core/analysis.py
@@ -61,6 +61,19 @@ from ansys.sherlock.core.types.analysis_types import (
 )
 from ansys.sherlock.core.utils.version_check import require_version
 
+RunStrainMapAnalysisType = (
+    SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType
+)
+PcbModelingAnalysisType = (
+    SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType
+)
+PcbModelType = (
+    SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType
+)
+PcbMaterialModel = (
+    SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType
+)
+
 
 class Analysis(GrpcStub):
     """Contains all analysis capabilities."""
@@ -1548,12 +1561,7 @@ class Analysis(GrpcStub):
         self,
         project: str,
         cca_name: str,
-        strain_map_analyses: list[
-            list[
-                SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType  # noqa: E501
-                | list[list[str]]
-            ]
-        ],
+        strain_map_analyses: list[list[RunStrainMapAnalysisType | list[list[str]]]],
     ) -> int:
         """Run one or more strain map analyses.
 
@@ -1734,9 +1742,9 @@ class Analysis(GrpcStub):
                 bool
                 | float
                 | str
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType  # noqa: E501
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType  # noqa: E501
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType  # noqa: E501
+                | PcbModelingAnalysisType
+                | PcbModelType
+                | PcbMaterialModel
                 | SherlockAnalysisService_pb2.ElementOrder.ValueType,
                 ...,
             ]

--- a/src/ansys/sherlock/core/analysis.py
+++ b/src/ansys/sherlock/core/analysis.py
@@ -50,17 +50,10 @@ from ansys.sherlock.core.errors import (
 )
 from ansys.sherlock.core.grpc_stub import GrpcStub
 from ansys.sherlock.core.types.analysis_types import (
-    ElementOrder,
-    ModelSource,
-    RunAnalysisRequestAnalysisType,
-    RunStrainMapAnalysisRequestAnalysisType,
     UpdateComponentFailureMechanismPropsRequest,
     UpdateLeadModelingPropsRequest,
     UpdateMechanicalPartsPropsRequest,
     UpdateMountPointsPropsRequest,
-    UpdatePcbModelingPropsRequestAnalysisType,
-    UpdatePcbModelingPropsRequestPcbMaterialModel,
-    UpdatePcbModelingPropsRequestPcbModelType,
     UpdatePottingRegionsPropsRequest,
     UpdatePTHFatiguePropsRequest,
     UpdateSemiconductorWearoutAnalysisPropsRequest,
@@ -120,7 +113,9 @@ class Analysis(GrpcStub):
     @staticmethod
     def _add_analyses(
         request: SherlockAnalysisService_pb2.RunAnalysisRequest,
-        analyses: list[tuple[RunAnalysisRequestAnalysisType, tuple[str, str]]],
+        analyses: list[
+            tuple[SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType, tuple[str, str]]
+        ],
     ):
         """Add analyses."""
         for a in analyses:
@@ -138,7 +133,9 @@ class Analysis(GrpcStub):
         self,
         project: str,
         cca_name: str,
-        analyses: list[tuple[RunAnalysisRequestAnalysisType, tuple[str, str]]],
+        analyses: list[
+            tuple[SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType, tuple[str, str]]
+        ],
     ) -> int:
         """Run one or more Sherlock analyses.
 
@@ -152,10 +149,10 @@ class Analysis(GrpcStub):
             Name of the CCA.
         analyses: list of ``elements``
 
-            - elements: list[tuple[RunAnalysisRequestAnalysisType, tuple[str, str]]]
+            - elements: list[tuple[SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType, tuple[str, str]]]
                 Tuples (``type``, ``event``)
 
-                - analysis_type: RunAnalysisRequestAnalysisType
+                - analysis_type: SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType
                     Type of analysis to run.
 
                 - event: list[tuple[str, str]]
@@ -188,7 +185,7 @@ class Analysis(GrpcStub):
         >>>    "Test",
         >>>    "Card",
         >>>    [
-        >>>        (RunAnalysisRequestAnalysisType.NATURAL_FREQ,
+        >>>        (SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.NaturalFreq,
         >>>        [
         >>>            ("Phase 1", ["Harmonic Event"])
         >>>        ]
@@ -233,7 +230,8 @@ class Analysis(GrpcStub):
 
     @require_version()
     def get_harmonic_vibe_input_fields(
-        self, model_source: Optional[ModelSource] = None
+        self,
+        model_source: Optional[SherlockAnalysisService_pb2.ModelSource.ValueType] = None,
     ) -> list[str]:
         """Get harmonic vibe property fields based on the user configuration.
 
@@ -241,7 +239,7 @@ class Analysis(GrpcStub):
 
         Parameters
         ----------
-        model_source: ModelSource, optional
+        model_source: SherlockAnalysisService_pb2.ModelSource.ValueType, optional
             Model source to get the harmonic vibe property fields from.
             The default is ``None``.
 
@@ -263,7 +261,9 @@ class Analysis(GrpcStub):
         >>>     project="Test",
         >>>     cca_name="Card",
         >>> )
-        >>> sherlock.analysis.get_harmonic_vibe_input_fields(ModelSource.GENERATED)
+        >>> sherlock.analysis.get_harmonic_vibe_input_fields(
+        >>>     SherlockAnalysisService_pb2.ModelSource.GENERATED
+        >>> )
         """
         if not self._is_connection_up():
             raise SherlockNoGrpcConnectionException()
@@ -295,7 +295,7 @@ class Analysis(GrpcStub):
 
             - cca_name: str
                 Name of the CCA.
-            - model_source: ModelSource
+            - model_source: SherlockAnalysisService_pb2.ModelSource.ValueType
                 Model source. The default is ``None``.
             - harmonic_vibe_count: int
                 Number of harmonic vibe result layers to generate. The default is ``None``.
@@ -359,7 +359,7 @@ class Analysis(GrpcStub):
         >>> "Test",
         >>> [{
         >>>     "cca_name": "Card",
-        >>>     "model_source": ModelSource.GENERATED,
+        >>>     "model_source": SherlockAnalysisService_pb2.ModelSource.GENERATED,
         >>>     "harmonic_vibe_count": 2,
         >>>     "harmonic_vibe_damping": "0.01, 0.05",
         >>>     "part_validation_enabled": False,
@@ -748,7 +748,8 @@ class Analysis(GrpcStub):
 
     @require_version(241)
     def get_mechanical_shock_input_fields(
-        self, model_source: Optional[ModelSource] = None
+        self,
+        model_source: Optional[SherlockAnalysisService_pb2.ModelSource.ValueType] = None,
     ) -> list[str]:
         """Get mechanical shock property fields based on the user configuration.
 
@@ -756,7 +757,7 @@ class Analysis(GrpcStub):
 
         Parameters
         ----------
-        model_source: ModelSource, optional
+        model_source: SherlockAnalysisService_pb2.ModelSource.ValueType, optional
             Model source to get the random vibe property fields from.
             Only GENERATED is supported.
             Default is ``None``.
@@ -779,7 +780,9 @@ class Analysis(GrpcStub):
         >>>     project="Test",
         >>>     cca_name="Card",
         >>> )
-        >>> sherlock.analysis.get_mechanical_shock_input_fields(ModelSource.GENERATED)
+        >>> sherlock.analysis.get_mechanical_shock_input_fields(
+        >>>     SherlockAnalysisService_pb2.ModelSource.GENERATED
+        >>> )
         """
         if not self._is_connection_up():
             raise SherlockNoGrpcConnectionException()
@@ -813,7 +816,7 @@ class Analysis(GrpcStub):
 
             - cca_name: str
                 Name of the CCA.
-            - model_source: ModelSource, optional
+            - model_source: SherlockAnalysisService_pb2.ModelSource.ValueType, optional
                 Model source. The default is ``None``.
             - shock_result_count : int
                 Number of mechanical shock result layers to generate.
@@ -867,7 +870,7 @@ class Analysis(GrpcStub):
         >>> "Test",
         >>> [{
         >>>     "cca_name": "Card",
-        >>>     "model_source": ModelSource.GENERATED,
+        >>>     "model_source": SherlockAnalysisService_pb2.ModelSource.GENERATED,
         >>>     "shock_result_count": 2,
         >>>     "critical_shock_strain": 10,
         >>>     "critical_shock_strain_units": "strain",
@@ -1174,14 +1177,17 @@ class Analysis(GrpcStub):
             raise e
 
     @require_version()
-    def get_random_vibe_input_fields(self, model_source: Optional[ModelSource] = None) -> list[str]:
+    def get_random_vibe_input_fields(
+        self,
+        model_source: Optional[SherlockAnalysisService_pb2.ModelSource.ValueType] = None,
+    ) -> list[str]:
         """Get random vibe property fields based on the user configuration.
 
         Available Since: 2023R2
 
         Parameters
         ----------
-        model_source: ModelSource, optional
+        model_source: SherlockAnalysisService_pb2.ModelSource.ValueType, optional
             Model source to get the random vibe property fields from.
             The default is ``None``.
 
@@ -1203,7 +1209,9 @@ class Analysis(GrpcStub):
         >>>     project="Test",
         >>>     cca_name="Card",
         >>> )
-        >>> sherlock.analysis.get_random_vibe_input_fields(ModelSource.STRAIN_MAP)
+        >>> sherlock.analysis.get_random_vibe_input_fields(
+        >>>     SherlockAnalysisService_pb2.ModelSource.STRAIN_MAP
+        >>> )
         """
         if not self._is_connection_up():
             raise SherlockNoGrpcConnectionException()
@@ -1233,7 +1241,7 @@ class Analysis(GrpcStub):
         reuse_modal_analysis: Optional[bool] = None,
         perform_nf_freq_range_check: Optional[bool] = None,
         require_material_assignment_enabled: Optional[bool] = None,
-        model_source: Optional[ModelSource] = None,
+        model_source: Optional[SherlockAnalysisService_pb2.ModelSource.ValueType] = None,
         strain_map_natural_freqs: Optional[str] = None,
     ) -> int:
         """Update properties for a random vibe analysis.
@@ -1281,7 +1289,7 @@ class Analysis(GrpcStub):
             This parameter is for NX Nastran analysis only.
         require_material_assignment_enabled: bool, optional
             Whether to require material assignment. The default is ``None``.
-        model_source: ModelSource, optional
+        model_source: SherlockAnalysisService_pb2.ModelSource.ValueType, optional
             Model source. The default is ``None``.
             This parameter is required for strain map analysis.
         strain_map_natural_freqs: str, optional
@@ -1312,7 +1320,7 @@ class Analysis(GrpcStub):
         >>>     random_vibe_damping="0.01, 0.05",
         >>>     analysis_temp=20,
         >>>     analysis_temp_units="C",
-        >>>     model_source=ModelSource.STRAIN_MAP
+        >>>     model_source=SherlockAnalysisService_pb2.ModelSource.STRAIN_MAP
         >>> )
         """
         try:
@@ -1525,7 +1533,9 @@ class Analysis(GrpcStub):
         self,
         project: str,
         cca_name: str,
-        strain_map_analyses: list[list[RunStrainMapAnalysisRequestAnalysisType | list[list[str]]]],
+        strain_map_analyses: list[
+            list[SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType | list[list[str]]]
+        ],
     ) -> int:
         """Run one or more strain map analyses.
 
@@ -1537,10 +1547,10 @@ class Analysis(GrpcStub):
             Name of the Sherlock project.
         cca_name: str
             Name of the main CCA for the analysis.
-        strain_map_analyses: list[list[RunStrainMapAnalysisRequestAnalysisType | list[list[str]]]]
+        strain_map_analyses: list[list[SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType | list[list[str]]]]
             Analyses consisting of these properties:
 
-            - analysis_type: RunStrainMapAnalysisRequestAnalysisType
+            - analysis_type: SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType
                 Type of analysis to run.
             - event_strain_maps: list
                 Strain maps assigned to the desired life cycle events for
@@ -1564,9 +1574,7 @@ class Analysis(GrpcStub):
 
         Examples
         --------
-        >>> from ansys.sherlock.core.types.analysis_types import (
-        >>>     RunStrainMapAnalysisRequestAnalysisType
-        >>> )
+        >>> from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2
         >>> from ansys.sherlock.core import launcher
         >>> sherlock, install_dir = launcher.launch_and_connect(transport_mode="wnua")
         >>> analysis_request = SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest
@@ -1574,7 +1582,7 @@ class Analysis(GrpcStub):
         >>>     "AssemblyTutorial",
         >>>     "Main Board",
         >>>     [[
-        >>>         RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+        >>>         SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
         >>>         [["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
         >>>          ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
         >>>          ["Phase 1", "Random Vibe", "TOP", "MemoryCard1Strain", "Memory Card 1"]],
@@ -1693,10 +1701,10 @@ class Analysis(GrpcStub):
                 bool
                 | float
                 | str
-                | UpdatePcbModelingPropsRequestAnalysisType
-                | UpdatePcbModelingPropsRequestPcbModelType
-                | UpdatePcbModelingPropsRequestPcbMaterialModel
-                | ElementOrder,
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType
+                | SherlockAnalysisService_pb2.ElementOrder.ValueType,
                 ...,
             ]
         ],
@@ -1711,24 +1719,24 @@ class Analysis(GrpcStub):
             Name of the Sherlock project.
         cca_names: list
             Names of the CCAs to be used for the analysis.
-        analyses: list[tuple[bool | float | str | UpdatePcbModelingPropsRequestAnalysisType\
-                | UpdatePcbModelingPropsRequestPcbModelType\
-                | UpdatePcbModelingPropsRequestPcbMaterialModel\
-                | ElementOrder, ...]]
+        analyses: list[tuple[bool | float | str | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType\
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType\
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType\
+                | SherlockAnalysisService_pb2.ElementOrder.ValueType, ...]]
             Elements consisting of the following properties:
 
-            - analysis_type: UpdatePcbModelingPropsRequestAnalysisType
+            - analysis_type: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType
                 Type of analysis applied.
-            - pcb_model_type: UpdatePcbModelingPropsRequestPcbModelType
+            - pcb_model_type: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType
                 The PCB modeling mesh type.
             - modeling_region_enabled: bool
                 Indicates if modeling regions are enabled.
-            - pcb_material_model: UpdatePcbModelingPropsRequestPcbMaterialModel
+            - pcb_material_model: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType
                 The PCB modeling PCB model type.
             - pcb_max_materials: Optional[int]
                 The number of PCB materials for Uniform Elements and Layered Elements PCB model
                 types. Not applicable if PCB model is Uniform or Layered.
-            - pcb_elem_order: ElementOrder
+            - pcb_elem_order: SherlockAnalysisService_pb2.ElementOrder.ValueType
                 The element order for PCB elements.
             - pcb_max_edge_length: float
                 The maximum mesh size for PCB elements.
@@ -1757,11 +1765,11 @@ class Analysis(GrpcStub):
         >>> ["Main Board"],
         >>> [
         >>>     (
-        >>>         UpdatePcbModelingPropsRequestAnalysisType.HARMONIC_VIBE,
-        >>>         UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.HarmonicVibe,
+        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
         >>>         True,
-        >>>         UpdatePcbModelingPropsRequestPcbMaterialModel.UNIFORM,
-        >>>         ElementOrder.SOLID_SHELL,
+        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+        >>>         SherlockAnalysisService_pb2.ElementOrder.SolidShell,
         >>>         6,
         >>>         "mm",
         >>>         3,

--- a/src/ansys/sherlock/core/analysis.py
+++ b/src/ansys/sherlock/core/analysis.py
@@ -114,7 +114,10 @@ class Analysis(GrpcStub):
     def _add_analyses(
         request: SherlockAnalysisService_pb2.RunAnalysisRequest,
         analyses: list[
-            tuple[SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType, tuple[str, str]]
+            tuple[
+                SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType,
+                tuple[str, str],
+            ]
         ],
     ):
         """Add analyses."""
@@ -134,7 +137,10 @@ class Analysis(GrpcStub):
         project: str,
         cca_name: str,
         analyses: list[
-            tuple[SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType, tuple[str, str]]
+            tuple[
+                SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType,
+                tuple[str, str],
+            ]
         ],
     ) -> int:
         """Run one or more Sherlock analyses.
@@ -149,10 +155,17 @@ class Analysis(GrpcStub):
             Name of the CCA.
         analyses: list of ``elements``
 
-            - elements: list[tuple[SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType, tuple[str, str]]]
+            - elements: list[
+                tuple[
+                    SherlockAnalysisService_pb2.RunAnalysisRequest.
+                    Analysis.AnalysisType.ValueType,
+                    tuple[str, str],
+                ]
+              ]
                 Tuples (``type``, ``event``)
 
-                - analysis_type: SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType
+                - analysis_type: SherlockAnalysisService_pb2.RunAnalysisRequest.
+                  Analysis.AnalysisType.ValueType
                     Type of analysis to run.
 
                 - event: list[tuple[str, str]]
@@ -185,10 +198,12 @@ class Analysis(GrpcStub):
         >>>    "Test",
         >>>    "Card",
         >>>    [
-        >>>        (SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.NaturalFreq,
-        >>>        [
-        >>>            ("Phase 1", ["Harmonic Event"])
-        >>>        ]
+        >>>        (
+        >>>            SherlockAnalysisService_pb2.RunAnalysisRequest.
+        >>>            Analysis.AnalysisType.NaturalFreq,
+        >>>            [
+        >>>                ("Phase 1", ["Harmonic Event"])
+        >>>            ],
         >>>        )
         >>>    ]
         >>> )
@@ -1534,7 +1549,10 @@ class Analysis(GrpcStub):
         project: str,
         cca_name: str,
         strain_map_analyses: list[
-            list[SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType | list[list[str]]]
+            list[
+                SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType  # noqa: E501
+                | list[list[str]]
+            ]
         ],
     ) -> int:
         """Run one or more strain map analyses.
@@ -1547,10 +1565,16 @@ class Analysis(GrpcStub):
             Name of the Sherlock project.
         cca_name: str
             Name of the main CCA for the analysis.
-        strain_map_analyses: list[list[SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType | list[list[str]]]]
+        strain_map_analyses: list[
+            list[
+                SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.
+                StrainMapAnalysis.AnalysisType.ValueType | list[list[str]]
+            ]
+        ]
             Analyses consisting of these properties:
 
-            - analysis_type: SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType
+            - analysis_type: SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.
+              StrainMapAnalysis.AnalysisType.ValueType
                 Type of analysis to run.
             - event_strain_maps: list
                 Strain maps assigned to the desired life cycle events for
@@ -1582,10 +1606,19 @@ class Analysis(GrpcStub):
         >>>     "AssemblyTutorial",
         >>>     "Main Board",
         >>>     [[
-        >>>         SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
-        >>>         [["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
-        >>>          ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
-        >>>          ["Phase 1", "Random Vibe", "TOP", "MemoryCard1Strain", "Memory Card 1"]],
+        >>>         SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.
+        >>>         StrainMapAnalysis.AnalysisType.RandomVibe,
+        >>>         [
+        >>>             ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
+        >>>             ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
+        >>>             [
+        >>>                 "Phase 1",
+        >>>                 "Random Vibe",
+        >>>                 "TOP",
+        >>>                 "MemoryCard1Strain",
+        >>>                 "Memory Card 1",
+        >>>             ],
+        >>>         ],
         >>>     ]]
         >>> )
         """
@@ -1701,9 +1734,9 @@ class Analysis(GrpcStub):
                 bool
                 | float
                 | str
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType  # noqa: E501
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType  # noqa: E501
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType  # noqa: E501
                 | SherlockAnalysisService_pb2.ElementOrder.ValueType,
                 ...,
             ]
@@ -1719,19 +1752,33 @@ class Analysis(GrpcStub):
             Name of the Sherlock project.
         cca_names: list
             Names of the CCAs to be used for the analysis.
-        analyses: list[tuple[bool | float | str | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType\
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType\
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType\
-                | SherlockAnalysisService_pb2.ElementOrder.ValueType, ...]]
+        analyses: list[
+            tuple[
+                bool
+                | float
+                | str
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
+                Analysis.AnalysisType.ValueType
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
+                Analysis.PcbModelType.ValueType
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
+                Analysis.PcbMaterialModel.ValueType
+                | SherlockAnalysisService_pb2.ElementOrder.ValueType,
+                ...,
+            ]
+        ]
             Elements consisting of the following properties:
 
-            - analysis_type: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType
+            - analysis_type: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
+              Analysis.AnalysisType.ValueType
                 Type of analysis applied.
-            - pcb_model_type: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType
+            - pcb_model_type: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
+              Analysis.PcbModelType.ValueType
                 The PCB modeling mesh type.
             - modeling_region_enabled: bool
                 Indicates if modeling regions are enabled.
-            - pcb_material_model: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType
+            - pcb_material_model: SherlockAnalysisService_pb2.
+              UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType
                 The PCB modeling PCB model type.
             - pcb_max_materials: Optional[int]
                 The number of PCB materials for Uniform Elements and Layered Elements PCB model
@@ -1765,10 +1812,13 @@ class Analysis(GrpcStub):
         >>> ["Main Board"],
         >>> [
         >>>     (
-        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.HarmonicVibe,
-        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
+        >>>         Analysis.AnalysisType.HarmonicVibe,
+        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
+        >>>         Analysis.PcbModelType.Bonded,
         >>>         True,
-        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
+        >>>         Analysis.PcbMaterialModel.Uniform,
         >>>         SherlockAnalysisService_pb2.ElementOrder.SolidShell,
         >>>         6,
         >>>         "mm",

--- a/src/ansys/sherlock/core/analysis.py
+++ b/src/ansys/sherlock/core/analysis.py
@@ -114,10 +114,7 @@ class Analysis(GrpcStub):
     def _add_analyses(
         request: SherlockAnalysisService_pb2.RunAnalysisRequest,
         analyses: list[
-            tuple[
-                SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType,
-                tuple[str, str],
-            ]
+            tuple[SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType, tuple[str, str]]
         ],
     ):
         """Add analyses."""
@@ -137,10 +134,7 @@ class Analysis(GrpcStub):
         project: str,
         cca_name: str,
         analyses: list[
-            tuple[
-                SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType,
-                tuple[str, str],
-            ]
+            tuple[SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType, tuple[str, str]]
         ],
     ) -> int:
         """Run one or more Sherlock analyses.
@@ -155,17 +149,10 @@ class Analysis(GrpcStub):
             Name of the CCA.
         analyses: list of ``elements``
 
-            - elements: list[
-                tuple[
-                    SherlockAnalysisService_pb2.RunAnalysisRequest.
-                    Analysis.AnalysisType.ValueType,
-                    tuple[str, str],
-                ]
-              ]
+            - elements: list[tuple[SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType, tuple[str, str]]]
                 Tuples (``type``, ``event``)
 
-                - analysis_type: SherlockAnalysisService_pb2.RunAnalysisRequest.
-                  Analysis.AnalysisType.ValueType
+                - analysis_type: SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.ValueType
                     Type of analysis to run.
 
                 - event: list[tuple[str, str]]
@@ -198,12 +185,10 @@ class Analysis(GrpcStub):
         >>>    "Test",
         >>>    "Card",
         >>>    [
-        >>>        (
-        >>>            SherlockAnalysisService_pb2.RunAnalysisRequest.
-        >>>            Analysis.AnalysisType.NaturalFreq,
-        >>>            [
-        >>>                ("Phase 1", ["Harmonic Event"])
-        >>>            ],
+        >>>        (SherlockAnalysisService_pb2.RunAnalysisRequest.Analysis.AnalysisType.NaturalFreq,
+        >>>        [
+        >>>            ("Phase 1", ["Harmonic Event"])
+        >>>        ]
         >>>        )
         >>>    ]
         >>> )
@@ -1549,10 +1534,7 @@ class Analysis(GrpcStub):
         project: str,
         cca_name: str,
         strain_map_analyses: list[
-            list[
-                SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType  # noqa: E501
-                | list[list[str]]
-            ]
+            list[SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType | list[list[str]]]
         ],
     ) -> int:
         """Run one or more strain map analyses.
@@ -1565,16 +1547,10 @@ class Analysis(GrpcStub):
             Name of the Sherlock project.
         cca_name: str
             Name of the main CCA for the analysis.
-        strain_map_analyses: list[
-            list[
-                SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.
-                StrainMapAnalysis.AnalysisType.ValueType | list[list[str]]
-            ]
-        ]
+        strain_map_analyses: list[list[SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType | list[list[str]]]]
             Analyses consisting of these properties:
 
-            - analysis_type: SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.
-              StrainMapAnalysis.AnalysisType.ValueType
+            - analysis_type: SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.ValueType
                 Type of analysis to run.
             - event_strain_maps: list
                 Strain maps assigned to the desired life cycle events for
@@ -1606,19 +1582,10 @@ class Analysis(GrpcStub):
         >>>     "AssemblyTutorial",
         >>>     "Main Board",
         >>>     [[
-        >>>         SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.
-        >>>         StrainMapAnalysis.AnalysisType.RandomVibe,
-        >>>         [
-        >>>             ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
-        >>>             ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
-        >>>             [
-        >>>                 "Phase 1",
-        >>>                 "Random Vibe",
-        >>>                 "TOP",
-        >>>                 "MemoryCard1Strain",
-        >>>                 "Memory Card 1",
-        >>>             ],
-        >>>         ],
+        >>>         SherlockAnalysisService_pb2.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+        >>>         [["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
+        >>>          ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
+        >>>          ["Phase 1", "Random Vibe", "TOP", "MemoryCard1Strain", "Memory Card 1"]],
         >>>     ]]
         >>> )
         """
@@ -1734,9 +1701,9 @@ class Analysis(GrpcStub):
                 bool
                 | float
                 | str
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType  # noqa: E501
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType  # noqa: E501
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType  # noqa: E501
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType
                 | SherlockAnalysisService_pb2.ElementOrder.ValueType,
                 ...,
             ]
@@ -1752,33 +1719,19 @@ class Analysis(GrpcStub):
             Name of the Sherlock project.
         cca_names: list
             Names of the CCAs to be used for the analysis.
-        analyses: list[
-            tuple[
-                bool
-                | float
-                | str
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
-                Analysis.AnalysisType.ValueType
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
-                Analysis.PcbModelType.ValueType
-                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
-                Analysis.PcbMaterialModel.ValueType
-                | SherlockAnalysisService_pb2.ElementOrder.ValueType,
-                ...,
-            ]
-        ]
+        analyses: list[tuple[bool | float | str | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType\
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType\
+                | SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType\
+                | SherlockAnalysisService_pb2.ElementOrder.ValueType, ...]]
             Elements consisting of the following properties:
 
-            - analysis_type: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
-              Analysis.AnalysisType.ValueType
+            - analysis_type: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.ValueType
                 Type of analysis applied.
-            - pcb_model_type: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
-              Analysis.PcbModelType.ValueType
+            - pcb_model_type: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.ValueType
                 The PCB modeling mesh type.
             - modeling_region_enabled: bool
                 Indicates if modeling regions are enabled.
-            - pcb_material_model: SherlockAnalysisService_pb2.
-              UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType
+            - pcb_material_model: SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.ValueType
                 The PCB modeling PCB model type.
             - pcb_max_materials: Optional[int]
                 The number of PCB materials for Uniform Elements and Layered Elements PCB model
@@ -1812,13 +1765,10 @@ class Analysis(GrpcStub):
         >>> ["Main Board"],
         >>> [
         >>>     (
-        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
-        >>>         Analysis.AnalysisType.HarmonicVibe,
-        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
-        >>>         Analysis.PcbModelType.Bonded,
+        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.HarmonicVibe,
+        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
         >>>         True,
-        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.
-        >>>         Analysis.PcbMaterialModel.Uniform,
+        >>>         SherlockAnalysisService_pb2.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
         >>>         SherlockAnalysisService_pb2.ElementOrder.SolidShell,
         >>>         6,
         >>>         "mm",

--- a/src/ansys/sherlock/core/model.py
+++ b/src/ansys/sherlock/core/model.py
@@ -499,7 +499,9 @@ class Model(GrpcStub):
         mesh_type: int = MeshType.NONE,
         is_modeling_region_enabled: bool = False,
         trace_output_type: int = TraceOutputType.ALL_REGIONS,
-        element_order: SherlockAnalysisService_pb2.ElementOrder.ValueType = SherlockAnalysisService_pb2.ElementOrder.Linear,
+        element_order: SherlockAnalysisService_pb2.ElementOrder.ValueType = (
+            SherlockAnalysisService_pb2.ElementOrder.Linear
+        ),
         max_mesh_size: float = 1.0,
         max_mesh_size_units: str = "mm",
         max_holes_per_trace: int = 2,
@@ -548,7 +550,9 @@ class Model(GrpcStub):
             Determines if pre-defined modeling regions will be applied to the exported trace model.
         trace_output_type: TraceOutputType = TraceOutputType.ALL_REGIONS
             Options to select which trace regions to include in the 3D model.
-        element_order: SherlockAnalysisService_pb2.ElementOrder.ValueType = SherlockAnalysisService_pb2.ElementOrder.Linear
+        element_order: SherlockAnalysisService_pb2.ElementOrder.ValueType = (
+            SherlockAnalysisService_pb2.ElementOrder.Linear
+        )
             Type of FEA element to be used when modeling each component.
         max_mesh_size: float = 1.0
             Indicates the desired element sizes.

--- a/src/ansys/sherlock/core/model.py
+++ b/src/ansys/sherlock/core/model.py
@@ -25,7 +25,11 @@
 """Module containing all model generation capabilities."""
 import os.path
 
-from ansys.api.sherlock.v0 import SherlockModelService_pb2, SherlockModelService_pb2_grpc
+from ansys.api.sherlock.v0 import (
+    SherlockAnalysisService_pb2,
+    SherlockModelService_pb2,
+    SherlockModelService_pb2_grpc,
+)
 from ansys.api.sherlock.v0.SherlockModelService_pb2 import (
     GeometryType,
     MeshType,
@@ -42,7 +46,6 @@ from ansys.sherlock.core.errors import (
     SherlockNoGrpcConnectionException,
 )
 from ansys.sherlock.core.grpc_stub import GrpcStub
-from ansys.sherlock.core.types.analysis_types import ElementOrder
 from ansys.sherlock.core.types.common_types import Measurement
 from ansys.sherlock.core.utils.version_check import require_version
 
@@ -432,7 +435,6 @@ class Model(GrpcStub):
 
         Examples
         --------
-        >>> from ansys.sherlock.core.types.analysis_types import ElementOrder
         >>> from ansys.sherlock.core import launcher
         >>> from ansys.api.sherlock.v0 import SherlockModelService_pb2
         >>> sherlock, ansys_install_path = launcher.launch_and_connect()
@@ -451,7 +453,7 @@ class Model(GrpcStub):
         >>>         mesh_type=SherlockModelService_pb2.MeshType.NONE,
         >>>         is_modeling_region_enabled=False,
         >>>         trace_output_type=SherlockModelService_pb2.TraceOutputType.ALL_REGIONS,
-        >>>         element_order=ElementOrder.LINEAR,
+        >>>         element_order=SherlockAnalysisService_pb2.ElementOrder.Linear,
         >>>         max_mesh_size=1.0,
         >>>         max_mesh_size_units="mm",
         >>>         max_holes_per_trace=2,
@@ -497,7 +499,7 @@ class Model(GrpcStub):
         mesh_type: int = MeshType.NONE,
         is_modeling_region_enabled: bool = False,
         trace_output_type: int = TraceOutputType.ALL_REGIONS,
-        element_order: ElementOrder = ElementOrder.LINEAR,
+        element_order: SherlockAnalysisService_pb2.ElementOrder.ValueType = SherlockAnalysisService_pb2.ElementOrder.Linear,
         max_mesh_size: float = 1.0,
         max_mesh_size_units: str = "mm",
         max_holes_per_trace: int = 2,
@@ -546,7 +548,7 @@ class Model(GrpcStub):
             Determines if pre-defined modeling regions will be applied to the exported trace model.
         trace_output_type: TraceOutputType = TraceOutputType.ALL_REGIONS
             Options to select which trace regions to include in the 3D model.
-        element_order: ElementOrder = ElementOrder.LINEAR
+        element_order: SherlockAnalysisService_pb2.ElementOrder.ValueType = SherlockAnalysisService_pb2.ElementOrder.Linear
             Type of FEA element to be used when modeling each component.
         max_mesh_size: float = 1.0
             Indicates the desired element sizes.
@@ -575,7 +577,6 @@ class Model(GrpcStub):
 
         Examples
         --------
-        >>> from ansys.sherlock.core.types.analysis_types import ElementOrder
         >>> from ansys.api.sherlock.v0 import SherlockModelService_pb2
         >>> from ansys.sherlock.core import launcher
         >>> sherlock, install_dir = launcher.launch_and_connect(transport_mode="wnua")
@@ -592,7 +593,7 @@ class Model(GrpcStub):
         >>>     SherlockModelService_pb2.MeshType.NONE,
         >>>     False,
         >>>     SherlockModelService_pb2.TraceOutputType.ALL_REGIONS,
-        >>>     ElementOrder.LINEAR,
+        >>>     SherlockAnalysisService_pb2.ElementOrder.Linear,
         >>>     1.0,
         >>>     "mm",
         >>>     2,
@@ -613,7 +614,7 @@ class Model(GrpcStub):
         >>>     SherlockModelService_pb2.MeshType.NONE,
         >>>     False,
         >>>     SherlockModelService_pb2.TraceOutputType.ALL_REGIONS,
-        >>>     ElementOrder.LINEAR,
+        >>>     SherlockAnalysisService_pb2.ElementOrder.Linear,
         >>>     1.0,
         >>>     "mm",
         >>>     2,

--- a/src/ansys/sherlock/core/model.py
+++ b/src/ansys/sherlock/core/model.py
@@ -499,9 +499,7 @@ class Model(GrpcStub):
         mesh_type: int = MeshType.NONE,
         is_modeling_region_enabled: bool = False,
         trace_output_type: int = TraceOutputType.ALL_REGIONS,
-        element_order: SherlockAnalysisService_pb2.ElementOrder.ValueType = (
-            SherlockAnalysisService_pb2.ElementOrder.Linear
-        ),
+        element_order: SherlockAnalysisService_pb2.ElementOrder.ValueType = SherlockAnalysisService_pb2.ElementOrder.Linear,
         max_mesh_size: float = 1.0,
         max_mesh_size_units: str = "mm",
         max_holes_per_trace: int = 2,
@@ -550,9 +548,7 @@ class Model(GrpcStub):
             Determines if pre-defined modeling regions will be applied to the exported trace model.
         trace_output_type: TraceOutputType = TraceOutputType.ALL_REGIONS
             Options to select which trace regions to include in the 3D model.
-        element_order: SherlockAnalysisService_pb2.ElementOrder.ValueType = (
-            SherlockAnalysisService_pb2.ElementOrder.Linear
-        )
+        element_order: SherlockAnalysisService_pb2.ElementOrder.ValueType = SherlockAnalysisService_pb2.ElementOrder.Linear
             Type of FEA element to be used when modeling each component.
         max_mesh_size: float = 1.0
             Indicates the desired element sizes.

--- a/src/ansys/sherlock/core/parts.py
+++ b/src/ansys/sherlock/core/parts.py
@@ -46,12 +46,9 @@ from ansys.sherlock.core.errors import (
 from ansys.sherlock.core.grpc_stub import GrpcStub
 from ansys.sherlock.core.types.common_types import TableDelimiter
 from ansys.sherlock.core.types.parts_types import (
-    AVLDescription,
-    AVLPartNum,
     DeletePartsFromPartsListRequest,
     GetPartsListPropertiesRequest,
     ImportPartsToAVLRequest,
-    PartsListSearchDuplicationMode,
     UpdatePadPropertiesRequest,
 )
 from ansys.sherlock.core.utils.version_check import require_version
@@ -185,7 +182,7 @@ class Parts(GrpcStub):
         cca_name: str,
         part_library: str,
         matching_mode: str,
-        duplication_mode: PartsListSearchDuplicationMode,
+        duplication_mode: SherlockPartsService_pb2.DuplicationMode.ValueType,
     ) -> int:
         """Update a parts list based on matching and duplication preferences.
 
@@ -201,7 +198,7 @@ class Parts(GrpcStub):
             Name of the parts library.
         matching_mode: str
             Matching mode for updates.
-        duplication_mode: PartsListSearchDuplicationMode
+        duplication_mode: SherlockPartsService_pb2.DuplicationMode.ValueType
             How to handle duplication during the update.
 
         Returns
@@ -211,8 +208,7 @@ class Parts(GrpcStub):
 
         Examples
         --------
-        >>> import SherlockCommonService_pb2
-        >>> import SherlockPartsService_pb2
+        >>> from ansys.api.sherlock.v0 import SherlockCommonService_pb2, SherlockPartsService_pb2
         >>> from ansys.sherlock.core import launcher
         >>> sherlock, install_dir = launcher.launch_and_connect(transport_mode="wnua")
         >>> sherlock.project.import_odb_archive(
@@ -721,9 +717,9 @@ class Parts(GrpcStub):
         project: str,
         cca_name: str,
         matching_mode: str,
-        duplication_mode: PartsListSearchDuplicationMode,
-        avl_part_num: AVLPartNum,
-        avl_description: AVLDescription,
+        duplication_mode: SherlockPartsService_pb2.DuplicationMode.ValueType,
+        avl_part_num: SherlockPartsService_pb2.AVLPartNum.ValueType,
+        avl_description: SherlockPartsService_pb2.AVLDescription.ValueType,
     ) -> SherlockPartsService_pb2.UpdatePartsListFromAVLResponse:
         r"""Update the parts list from the Approved Vendor List (AVL).
 
@@ -737,11 +733,11 @@ class Parts(GrpcStub):
             Name of the CCA.
         matching_mode: str
             Determines how parts are matched against the AVL
-        duplication_mode: PartsListSearchDuplicationMode
+        duplication_mode: SherlockPartsService_pb2.DuplicationMode.ValueType
             Determines how duplicate part matches are handled when found
-        avl_part_num: AVLPartNum
+        avl_part_num: SherlockPartsService_pb2.AVLPartNum.ValueType
             Determines what part number info in the parts list is updated from the AVL
-        avl_description: AVLDescription
+        avl_description: SherlockPartsService_pb2.AVLDescription.ValueType
             Determines if the part description is updated or not
 
         Returns
@@ -759,11 +755,7 @@ class Parts(GrpcStub):
 
         Examples
         --------
-        >>> from ansys.sherlock.core.types.parts_types import (
-            AVLDescription,
-            AVLPartNum,
-            PartsListSearchDuplicationMode,
-        )
+        >>> from ansys.api.sherlock.v0 import SherlockPartsService_pb2
         >>> from ansys.sherlock.core import launcher
         >>> sherlock, install_dir = launcher.launch_and_connect(transport_mode="wnua")
         >>> sherlock.project.import_odb_archive(
@@ -779,9 +771,9 @@ class Parts(GrpcStub):
         >>>     project="Test",
         >>>     cca_name="Card",
         >>>     matching_mode="Both",
-        >>>     duplication=PartsListSearchDuplicationMode.FIRST,
-        >>>     avl_part_num=AVLPartNum.ASSIGN_INTERNAL_PART_NUM,
-        >>>     avl_description=AVLDescription.ASSIGN_APPROVED_DESCRIPTION
+        >>>     duplication_mode=SherlockPartsService_pb2.DuplicationMode.First,
+        >>>     avl_part_num=SherlockPartsService_pb2.AVLPartNum.AssignInternalPartNum,
+        >>>     avl_description=SherlockPartsService_pb2.AVLDescription.AssignApprovedDescription,
         >>> )
         """
         try:

--- a/src/ansys/sherlock/core/project.py
+++ b/src/ansys/sherlock/core/project.py
@@ -703,7 +703,8 @@ class Project(GrpcStub):
                 ):
                     if len(strain_map) < 7 or len(strain_map) > 8:
                         raise SherlockAddStrainMapsError(
-                            f"Number of elements ({str(len(strain_maps))}) is wrong for strain map {i}."  # noqa: E501
+                            "Number of elements "
+                            f"({str(len(strain_maps))}) is wrong for strain map {i}."
                         )
                     elif not isinstance(strain_map[0], str) or strain_map[0] == "":
                         raise SherlockAddStrainMapsError(f"Path is required for strain map {i}.")

--- a/src/ansys/sherlock/core/types/analysis_types.py
+++ b/src/ansys/sherlock/core/types/analysis_types.py
@@ -27,52 +27,53 @@
 from enum import Enum
 from typing import Optional, cast
 
-from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2 as analysis_service
+from ansys.api.sherlock.v0 import SherlockAnalysisService_pb2 as AnalysisService
 from pydantic import BaseModel, ConfigDict, ValidationInfo, field_validator
 
-from ansys.sherlock.core.types.common_types import basic_str_validator
+from ansys.sherlock.core.types.common_types import basic_str_validator, deprecation
 
 TraceModelingAnalysisType = (
-    analysis_service.UpdateTraceModelingPropsRequest.Analysis.AnalysisType.ValueType
+    AnalysisService.UpdateTraceModelingPropsRequest.Analysis.AnalysisType.ValueType
 )
 MountPointsAnalysisType = (
-    analysis_service.UpdateMountPointsPropsRequest.Analysis.AnalysisType.ValueType
+    AnalysisService.UpdateMountPointsPropsRequest.Analysis.AnalysisType.ValueType
 )
 LeadModelingAnalysisType = (
-    analysis_service.UpdateLeadModelingPropsRequest.Analysis.AnalysisType.ValueType
+    AnalysisService.UpdateLeadModelingPropsRequest.Analysis.AnalysisType.ValueType
 )
-MechanicalPartsAnalysisType = (
-    analysis_service.UpdateMechanicalPartsPropsRequest.Analysis.AnalysisType.ValueType
-)
-PottingRegionsAnalysisType = (
-    analysis_service.UpdatePottingRegionsPropsRequest.Analysis.AnalysisType.ValueType
-)
+# These request types are no longer present in the generated protobuf API.
+# Keep compatibility aliases as deprecated placeholders for older integrations.
+MechanicalPartsAnalysisType = int
+PottingRegionsAnalysisType = int
 
 
+@deprecation("25.2")
 class ElementOrder:
     """Constants for Element Order."""
 
-    LINEAR = analysis_service.ElementOrder.Linear
+    LINEAR = AnalysisService.ElementOrder.Linear
     "LINEAR"
-    QUADRATIC = analysis_service.ElementOrder.Quadratic
+    QUADRATIC = AnalysisService.ElementOrder.Quadratic
     "QUADRATIC"
-    SOLID_SHELL = analysis_service.ElementOrder.SolidShell
+    SOLID_SHELL = AnalysisService.ElementOrder.SolidShell
     "SOLID_SHELL"
 
 
+@deprecation("25.2")
 class ModelSource:
     """Constants for Model Source."""
 
-    GENERATED = analysis_service.ModelSource.GENERATED
+    GENERATED = AnalysisService.ModelSource.GENERATED
     "GENERATED"
-    STRAIN_MAP = analysis_service.ModelSource.STRAIN_MAP
+    STRAIN_MAP = AnalysisService.ModelSource.STRAIN_MAP
     "STRAIN_MAP"
 
 
+@deprecation("25.2")
 class RunAnalysisRequestAnalysisType:
     """Constants for type of analysis in the Run Analysis request."""
 
-    __analysis_type = analysis_service.RunAnalysisRequest.Analysis.AnalysisType
+    __analysis_type = AnalysisService.RunAnalysisRequest.Analysis.AnalysisType
     NATURAL_FREQ = __analysis_type.NaturalFreq
     "NATURAL_FREQ"
     HARMONIC_VIBE = __analysis_type.HarmonicVibe
@@ -101,10 +102,11 @@ class RunAnalysisRequestAnalysisType:
     "THERMAL_MECH"
 
 
+@deprecation("25.2")
 class RunStrainMapAnalysisRequestAnalysisType:
     """Constants for type of analysis in the Run Strain Map Analysis request."""
 
-    __analysis_type = analysis_service.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType
+    __analysis_type = AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType
     HARMONIC_VIBE = __analysis_type.HarmonicVibe
     "HARMONIC_VIBE"
 
@@ -115,10 +117,11 @@ class RunStrainMapAnalysisRequestAnalysisType:
     "RANDOM_VIBE"
 
 
+@deprecation("25.2")
 class UpdatePcbModelingPropsRequestAnalysisType:
     """Constants for type of analysis in the Update PCB Modeling Properties Analysis request."""
 
-    __analysis_type = analysis_service.UpdatePcbModelingPropsRequest.Analysis.AnalysisType
+    __analysis_type = AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType
     HARMONIC_VIBE = __analysis_type.HarmonicVibe
     "HARMONIC_VIBE"
     ICT = __analysis_type.ICTAnalysis
@@ -133,10 +136,11 @@ class UpdatePcbModelingPropsRequestAnalysisType:
     "THERMAL_MECH"
 
 
+@deprecation("25.2")
 class UpdatePcbModelingPropsRequestPcbMaterialModel:
     """Constants for PCB Material Model in the Update PCB Modeling Properties Analysis request."""
 
-    __material_model = analysis_service.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel
+    __material_model = AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel
     UNIFORM = __material_model.Uniform
     "UNIFORM"
     LAYERED = __material_model.Layered
@@ -147,10 +151,11 @@ class UpdatePcbModelingPropsRequestPcbMaterialModel:
     "LAYERED_ELEMENTS"
 
 
+@deprecation("25.2")
 class UpdatePcbModelingPropsRequestPcbModelType:
     """Constants for PCB Model Type in the Update PCB Modeling Properties Analysis request."""
 
-    __model_type = analysis_service.UpdatePcbModelingPropsRequest.Analysis.PcbModelType
+    __model_type = AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType
     BONDED = __model_type.Bonded
     "BONDED"
 
@@ -172,10 +177,10 @@ class ComponentFailureMechanism(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdateComponentFailureMechanismPropsRequest.ComponentFailureMechanism:
+    ) -> AnalysisService.UpdateComponentFailureMechanismPropsRequest.ComponentFailureMechanism:
 
         grpc_data = (
-            analysis_service.UpdateComponentFailureMechanismPropsRequest.ComponentFailureMechanism()
+            AnalysisService.UpdateComponentFailureMechanismPropsRequest.ComponentFailureMechanism()
         )
 
         grpc_data.ccaName = self.cca_name
@@ -208,8 +213,8 @@ class UpdateComponentFailureMechanismPropsRequest(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdateComponentFailureMechanismPropsRequest:
-        request = analysis_service.UpdateComponentFailureMechanismPropsRequest()
+    ) -> AnalysisService.UpdateComponentFailureMechanismPropsRequest:
+        request = AnalysisService.UpdateComponentFailureMechanismPropsRequest()
         request.project = self.project
         for properties in self.component_failure_mechanism_properties_per_cca:
             request.componentFailureMechanismProperties.append(properties._convert_to_grpc())
@@ -238,10 +243,10 @@ class SemiconductorWearoutAnalysis(BaseModel):
     def _convert_to_grpc(
         self,
     ) -> (
-        analysis_service.UpdateSemiconductorWearoutAnalysisPropsRequest.SemiconductorWearoutAnalysis
+        AnalysisService.UpdateSemiconductorWearoutAnalysisPropsRequest.SemiconductorWearoutAnalysis
     ):
 
-        request_class = analysis_service.UpdateSemiconductorWearoutAnalysisPropsRequest
+        request_class = AnalysisService.UpdateSemiconductorWearoutAnalysisPropsRequest
         semiconductor_wearout_analysis = request_class.SemiconductorWearoutAnalysis
         grpc_data = semiconductor_wearout_analysis()
 
@@ -277,8 +282,8 @@ class UpdateSemiconductorWearoutAnalysisPropsRequest(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdateSemiconductorWearoutAnalysisPropsRequest:
-        request = analysis_service.UpdateSemiconductorWearoutAnalysisPropsRequest()
+    ) -> AnalysisService.UpdateSemiconductorWearoutAnalysisPropsRequest:
+        request = AnalysisService.UpdateSemiconductorWearoutAnalysisPropsRequest()
         request.project = self.project
         for properties in self.semiconductor_wearout_analysis_properties:
             request.semiconductorWearoutAnalysisProperties.append(properties._convert_to_grpc())
@@ -288,7 +293,7 @@ class UpdateSemiconductorWearoutAnalysisPropsRequest(BaseModel):
 class UpdatePTHFatiguePropsRequestAnalysisType(Enum):
     """Constants for qualification choices in the Update PTH Fatigue Properties request."""
 
-    __qualification = analysis_service.UpdatePTHFatiguePropsRequest.PTHFatigueAnalysis.Qualification
+    __qualification = AnalysisService.UpdatePTHFatiguePropsRequest.PTHFatigueAnalysis.Qualification
     NONE = __qualification.NONE
     "NONE"
     PER_LOT = __qualification.PER_LOT
@@ -325,8 +330,8 @@ class PTHFatiguePropsAnalysis(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdatePTHFatiguePropsRequest.PTHFatigueAnalysis:
-        grpc_data = analysis_service.UpdatePTHFatiguePropsRequest.PTHFatigueAnalysis()
+    ) -> AnalysisService.UpdatePTHFatiguePropsRequest.PTHFatigueAnalysis:
+        grpc_data = AnalysisService.UpdatePTHFatiguePropsRequest.PTHFatigueAnalysis()
 
         grpc_data.ccaName = self.cca_name
         if self.qualification is not None:
@@ -377,8 +382,8 @@ class UpdatePTHFatiguePropsRequest(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdatePTHFatiguePropsRequest:
-        request = analysis_service.UpdatePTHFatiguePropsRequest()
+    ) -> AnalysisService.UpdatePTHFatiguePropsRequest:
+        request = AnalysisService.UpdatePTHFatiguePropsRequest()
         request.project = self.project
         for properties in self.pth_fatigue_analysis_properties:
             request.pthFatigueAnalysisProperties.append(properties._convert_to_grpc())
@@ -392,7 +397,7 @@ class UpdateTraceModelingPropsAnalysis(BaseModel):
     """Analysis type."""
     trace_enabled: bool
     """Whether to enable trace modeling."""
-    trace_element_order: analysis_service.ElementOrder.ValueType
+    trace_element_order: AnalysisService.ElementOrder.ValueType
     """Trace modeling element order."""
     trace_max_edge_length: float
     """Trace max mesh size."""
@@ -403,8 +408,8 @@ class UpdateTraceModelingPropsAnalysis(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdateTraceModelingPropsRequest.Analysis:
-        grpc_data = analysis_service.UpdateTraceModelingPropsRequest.Analysis()
+    ) -> AnalysisService.UpdateTraceModelingPropsRequest.Analysis:
+        grpc_data = AnalysisService.UpdateTraceModelingPropsRequest.Analysis()
         grpc_data.type = self.analysis_type
         grpc_data.traceEnabled = self.trace_enabled
         grpc_data.traceElemOrder = self.trace_element_order
@@ -432,8 +437,8 @@ class UpdateTraceModelingPropsRequest(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdateTraceModelingPropsRequest:
-        request = analysis_service.UpdateTraceModelingPropsRequest()
+    ) -> AnalysisService.UpdateTraceModelingPropsRequest:
+        request = AnalysisService.UpdateTraceModelingPropsRequest()
         request.project = self.project
         for cca_name in self.cca_names:
             request.ccaNames.append(cca_name)
@@ -447,7 +452,7 @@ class UpdateMountPointsPropsAnalysis(BaseModel):
 
     analysis_type: MountPointsAnalysisType  # type: ignore[valid-type]
     """Analysis type."""
-    mount_points_element_order: analysis_service.ElementOrder.ValueType
+    mount_points_element_order: AnalysisService.ElementOrder.ValueType
     """Mount point element order."""
     mount_points_max_edge_length: float
     """Mount point maximum edge length."""
@@ -460,8 +465,8 @@ class UpdateMountPointsPropsAnalysis(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdateMountPointsPropsRequest.Analysis:
-        grpc_data = analysis_service.UpdateMountPointsPropsRequest.Analysis()
+    ) -> AnalysisService.UpdateMountPointsPropsRequest.Analysis:
+        grpc_data = AnalysisService.UpdateMountPointsPropsRequest.Analysis()
         grpc_data.type = self.analysis_type
         grpc_data.mountPtElemOrder = self.mount_points_element_order
         grpc_data.mountPtMaxEdgeLength = self.mount_points_max_edge_length
@@ -489,8 +494,8 @@ class UpdateMountPointsPropsRequest(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdateMountPointsPropsRequest:
-        request = analysis_service.UpdateMountPointsPropsRequest()
+    ) -> AnalysisService.UpdateMountPointsPropsRequest:
+        request = AnalysisService.UpdateMountPointsPropsRequest()
         request.project = self.project
         for cca_name in self.cca_names:
             request.ccaNames.append(cca_name)
@@ -506,7 +511,7 @@ class UpdateLeadModelingPropsAnalysis(BaseModel):
     """Analysis type."""
     model_leads: bool
     """Whether to enable lead modeling."""
-    lead_element_order: analysis_service.ElementOrder.ValueType
+    lead_element_order: AnalysisService.ElementOrder.ValueType
     """Lead modeling element order."""
     lead_max_edge_length: float
     """Lead modeling maximum edge length."""
@@ -519,8 +524,8 @@ class UpdateLeadModelingPropsAnalysis(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdateLeadModelingPropsRequest.Analysis:
-        grpc_data = analysis_service.UpdateLeadModelingPropsRequest.Analysis()
+    ) -> AnalysisService.UpdateLeadModelingPropsRequest.Analysis:
+        grpc_data = AnalysisService.UpdateLeadModelingPropsRequest.Analysis()
         grpc_data.type = self.analysis_type
         grpc_data.modelLeads = self.model_leads
         grpc_data.leadElemOrder = self.lead_element_order
@@ -549,8 +554,8 @@ class UpdateLeadModelingPropsRequest(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdateLeadModelingPropsRequest:
-        request = analysis_service.UpdateLeadModelingPropsRequest()
+    ) -> AnalysisService.UpdateLeadModelingPropsRequest:
+        request = AnalysisService.UpdateLeadModelingPropsRequest()
         request.project = self.project
         for cca_name in self.cca_names:
             request.ccaNames.append(cca_name)
@@ -566,7 +571,7 @@ class UpdateMechanicalPartsPropsAnalysis(BaseModel):
     """Analysis type."""
     mechanical_parts_enabled: bool
     """Whether to enable lead modeling."""
-    mechanical_parts_elem_order: analysis_service.ElementOrder.ValueType
+    mechanical_parts_elem_order: AnalysisService.ElementOrder.ValueType
     """Mechanical parts element order."""
     mechanical_parts_max_edge_length: float
     """Mechanical parts maximum edge length."""
@@ -579,8 +584,8 @@ class UpdateMechanicalPartsPropsAnalysis(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdateMechanicalPartsPropsRequest.Analysis:
-        grpc_data = analysis_service.UpdateMechanicalPartsPropsRequest.Analysis()
+    ) -> object:
+        grpc_data = AnalysisService.UpdateMechanicalPartsPropsRequest.Analysis()
         grpc_data.type = self.analysis_type
         grpc_data.mechanicalPartsEnabled = self.mechanical_parts_enabled
         grpc_data.mechanicalPartsElemOrder = self.mechanical_parts_elem_order
@@ -609,8 +614,8 @@ class UpdateMechanicalPartsPropsRequest(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdateMechanicalPartsPropsRequest:
-        request = analysis_service.UpdateMechanicalPartsPropsRequest()
+    ) -> object:
+        request = AnalysisService.UpdateMechanicalPartsPropsRequest()
         request.project = self.project
         for cca_name in self.cca_names:
             request.ccaNames.append(cca_name)
@@ -626,7 +631,7 @@ class UpdatePottingRegionsPropsAnalysis(BaseModel):
     """Analysis type."""
     potting_enabled: bool
     """Whether to enable potting regions."""
-    potting_elem_order: analysis_service.ElementOrder.ValueType
+    potting_elem_order: AnalysisService.ElementOrder.ValueType
     """Potting regions element order."""
     potting_max_edge_length: float
     """Potting regions maximum edge length."""
@@ -639,8 +644,8 @@ class UpdatePottingRegionsPropsAnalysis(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdatePottingRegionsPropsRequest.Analysis:
-        grpc_data = analysis_service.UpdatePottingRegionsPropsRequest.Analysis()
+    ) -> object:
+        grpc_data = AnalysisService.UpdatePottingRegionsPropsRequest.Analysis()
         grpc_data.type = self.analysis_type
         grpc_data.pottingEnabled = self.potting_enabled
         grpc_data.pottingElemOrder = self.potting_elem_order
@@ -669,8 +674,8 @@ class UpdatePottingRegionsPropsRequest(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> analysis_service.UpdatePottingRegionsPropsRequest:
-        request = analysis_service.UpdatePottingRegionsPropsRequest()
+    ) -> object:
+        request = AnalysisService.UpdatePottingRegionsPropsRequest()
         request.project = self.project
         for cca_name in self.cca_names:
             request.ccaNames.append(cca_name)

--- a/src/ansys/sherlock/core/types/analysis_types.py
+++ b/src/ansys/sherlock/core/types/analysis_types.py
@@ -41,13 +41,15 @@ MountPointsAnalysisType = (
 LeadModelingAnalysisType = (
     AnalysisService.UpdateLeadModelingPropsRequest.Analysis.AnalysisType.ValueType
 )
-# These request types are no longer present in the generated protobuf API.
-# Keep compatibility aliases as deprecated placeholders for older integrations.
-MechanicalPartsAnalysisType = int
-PottingRegionsAnalysisType = int
+MechanicalPartsAnalysisType = (
+    AnalysisService.UpdateMechanicalPartsPropsRequest.Analysis.AnalysisType.ValueType
+)
+PottingRegionsAnalysisType = (
+    AnalysisService.UpdatePottingRegionsPropsRequest.Analysis.AnalysisType.ValueType
+)
 
 
-@deprecation("25.2")
+@deprecation("27.1")
 class ElementOrder:
     """Constants for Element Order."""
 
@@ -59,7 +61,7 @@ class ElementOrder:
     "SOLID_SHELL"
 
 
-@deprecation("25.2")
+@deprecation("27.1")
 class ModelSource:
     """Constants for Model Source."""
 
@@ -69,7 +71,7 @@ class ModelSource:
     "STRAIN_MAP"
 
 
-@deprecation("25.2")
+@deprecation("27.1")
 class RunAnalysisRequestAnalysisType:
     """Constants for type of analysis in the Run Analysis request."""
 
@@ -102,7 +104,7 @@ class RunAnalysisRequestAnalysisType:
     "THERMAL_MECH"
 
 
-@deprecation("25.2")
+@deprecation("27.1")
 class RunStrainMapAnalysisRequestAnalysisType:
     """Constants for type of analysis in the Run Strain Map Analysis request."""
 
@@ -117,7 +119,7 @@ class RunStrainMapAnalysisRequestAnalysisType:
     "RANDOM_VIBE"
 
 
-@deprecation("25.2")
+@deprecation("27.1")
 class UpdatePcbModelingPropsRequestAnalysisType:
     """Constants for type of analysis in the Update PCB Modeling Properties Analysis request."""
 
@@ -136,7 +138,7 @@ class UpdatePcbModelingPropsRequestAnalysisType:
     "THERMAL_MECH"
 
 
-@deprecation("25.2")
+@deprecation("27.1")
 class UpdatePcbModelingPropsRequestPcbMaterialModel:
     """Constants for PCB Material Model in the Update PCB Modeling Properties Analysis request."""
 
@@ -151,7 +153,7 @@ class UpdatePcbModelingPropsRequestPcbMaterialModel:
     "LAYERED_ELEMENTS"
 
 
-@deprecation("25.2")
+@deprecation("27.1")
 class UpdatePcbModelingPropsRequestPcbModelType:
     """Constants for PCB Model Type in the Update PCB Modeling Properties Analysis request."""
 
@@ -312,7 +314,7 @@ class PTHFatiguePropsAnalysis(BaseModel):
     cca_name: str
     """Name of the CCA."""
     qualification: Optional[UpdatePTHFatiguePropsRequestAnalysisType] = None
-    """Qualification choice for IST/HATS."""  # noqa: E501
+    """Qualification choice for IST/HATS."""
     pth_quality_factor: Optional[str] = None
     """Quality factor for PTH."""
     pth_wall_thickness: Optional[float] = None
@@ -584,7 +586,7 @@ class UpdateMechanicalPartsPropsAnalysis(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> object:
+    ) -> AnalysisService.UpdateMechanicalPartsPropsRequest.Analysis:
         grpc_data = AnalysisService.UpdateMechanicalPartsPropsRequest.Analysis()
         grpc_data.type = self.analysis_type
         grpc_data.mechanicalPartsEnabled = self.mechanical_parts_enabled
@@ -614,7 +616,7 @@ class UpdateMechanicalPartsPropsRequest(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> object:
+    ) -> AnalysisService.UpdateMechanicalPartsPropsRequest:
         request = AnalysisService.UpdateMechanicalPartsPropsRequest()
         request.project = self.project
         for cca_name in self.cca_names:
@@ -644,7 +646,7 @@ class UpdatePottingRegionsPropsAnalysis(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> object:
+    ) -> AnalysisService.UpdatePottingRegionsPropsRequest.Analysis:
         grpc_data = AnalysisService.UpdatePottingRegionsPropsRequest.Analysis()
         grpc_data.type = self.analysis_type
         grpc_data.pottingEnabled = self.potting_enabled
@@ -674,7 +676,7 @@ class UpdatePottingRegionsPropsRequest(BaseModel):
 
     def _convert_to_grpc(
         self,
-    ) -> object:
+    ) -> AnalysisService.UpdatePottingRegionsPropsRequest:
         request = AnalysisService.UpdatePottingRegionsPropsRequest()
         request.project = self.project
         for cca_name in self.cca_names:

--- a/src/ansys/sherlock/core/types/common_types.py
+++ b/src/ansys/sherlock/core/types/common_types.py
@@ -29,7 +29,7 @@ import warnings
 from ansys.api.sherlock.v0 import SherlockCommonService_pb2
 
 
-def deprecation(version: str = "25.2"):
+def deprecation(version: str = "27.1"):
     """Raise a DeprecationWarning when a deprecated class is used."""
 
     def decorator(cls: object):

--- a/src/ansys/sherlock/core/types/common_types.py
+++ b/src/ansys/sherlock/core/types/common_types.py
@@ -24,7 +24,23 @@
 
 """Module containing types for the Common Service."""
 
+import warnings
+
 from ansys.api.sherlock.v0 import SherlockCommonService_pb2
+
+
+def deprecation(version: str = "25.2"):
+    """Raise a DeprecationWarning when a deprecated class is used."""
+
+    def decorator(cls: object):
+        message = (
+            f"{cls.__name__} is deprecated as of {version}. "
+            "Use the enum values defined in the generated .proto files instead."
+        )
+        warnings.warn(message, DeprecationWarning, stacklevel=2)
+        return cls
+
+    return decorator
 
 
 def basic_str_validator(value: str, field_name: str):

--- a/src/ansys/sherlock/core/types/layer_types.py
+++ b/src/ansys/sherlock/core/types/layer_types.py
@@ -673,7 +673,11 @@ class MountPointProperties(BaseModel):
 
 
 class GetMountPointsPropertiesRequest(BaseModel):
-    """Return the properties for each mount point given a comma-separated list of mount point ids."""  # noqa: E501
+    """Return the properties for each mount point given a comma-separated list of mount point ids.
+
+    The request can target a project and CCA and optionally restrict the results to
+    specific mount point IDs.
+    """
 
     project: str
     """Name of the project."""

--- a/src/ansys/sherlock/core/types/parts_types.py
+++ b/src/ansys/sherlock/core/types/parts_types.py
@@ -26,8 +26,7 @@
 
 from typing import List, Optional
 
-from ansys.api.sherlock.v0 import SherlockCommonService_pb2
-from ansys.api.sherlock.v0 import SherlockPartsService_pb2 as PartsService
+from ansys.api.sherlock.v0 import SherlockCommonService_pb2, SherlockPartsService_pb2 as PartsService
 from pydantic import BaseModel, field_validator
 
 from ansys.sherlock.core.types.common_types import basic_str_validator, deprecation

--- a/src/ansys/sherlock/core/types/parts_types.py
+++ b/src/ansys/sherlock/core/types/parts_types.py
@@ -26,7 +26,8 @@
 
 from typing import List, Optional
 
-from ansys.api.sherlock.v0 import SherlockCommonService_pb2, SherlockPartsService_pb2 as PartsService
+from ansys.api.sherlock.v0 import SherlockCommonService_pb2
+from ansys.api.sherlock.v0 import SherlockPartsService_pb2 as PartsService
 from pydantic import BaseModel, field_validator
 
 from ansys.sherlock.core.types.common_types import basic_str_validator, deprecation

--- a/src/ansys/sherlock/core/types/parts_types.py
+++ b/src/ansys/sherlock/core/types/parts_types.py
@@ -26,11 +26,11 @@
 
 from typing import List, Optional
 
-from ansys.api.sherlock.v0 import SherlockCommonService_pb2, SherlockPartsService_pb2 as PartsService
+from ansys.api.sherlock.v0 import SherlockCommonService_pb2
+from ansys.api.sherlock.v0 import SherlockPartsService_pb2 as PartsService
 from pydantic import BaseModel, field_validator
 
 from ansys.sherlock.core.types.common_types import basic_str_validator, deprecation
-
 
 
 @deprecation("25.2")

--- a/src/ansys/sherlock/core/types/parts_types.py
+++ b/src/ansys/sherlock/core/types/parts_types.py
@@ -25,25 +25,15 @@
 """Module containing types for the Parts Service."""
 
 from typing import List, Optional
-import warnings
 
-from ansys.api.sherlock.v0 import SherlockCommonService_pb2, SherlockPartsService_pb2
+from ansys.api.sherlock.v0 import SherlockCommonService_pb2, SherlockPartsService_pb2 as PartsService
 from pydantic import BaseModel, field_validator
 
-from ansys.sherlock.core.types.common_types import basic_str_validator
-
-parts_service = SherlockPartsService_pb2
+from ansys.sherlock.core.types.common_types import basic_str_validator, deprecation
 
 
-def deprecation(cls: object):
-    """Raise a DeprecationWarning when a deprecated class is used."""
-    message = f"{cls} is deprecated. Use a string with the value of the constant name \
-    as defined in the proto file."
-    warnings.warn(message, DeprecationWarning, stacklevel=2)
-    return cls
 
-
-@deprecation
+@deprecation("25.2")
 class PartsListSearchMatchingMode:
     """DEPRECATED. Constants for Matching Mode in Update Parts List & Update Parts from AVL."""
 
@@ -54,10 +44,11 @@ class PartsListSearchMatchingMode:
     """Part"""
 
 
+@deprecation("25.2")
 class PartsListSearchDuplicationMode:
     """Constants for Duplication Mode in Update Parts List and Update Parts from AVL request."""
 
-    duplication_mode = SherlockPartsService_pb2.DuplicationMode
+    duplication_mode = PartsService.DuplicationMode
     FIRST = duplication_mode.First
     """First"""
     ERROR = duplication_mode.Error
@@ -66,10 +57,11 @@ class PartsListSearchDuplicationMode:
     """Ignore"""
 
 
+@deprecation("25.2")
 class AVLPartNum:
     """Constants for AVLPartNum in the Update Parts List from AVL request."""
 
-    avl_part_num = SherlockPartsService_pb2.AVLPartNum
+    avl_part_num = PartsService.AVLPartNum
     ASSIGN_INTERNAL_PART_NUM = avl_part_num.AssignInternalPartNum
     """AssignInternalPartNum"""
     ASSIGN_VENDOR_AND_PART_NUM = avl_part_num.AssignVendorAndPartNum
@@ -78,10 +70,11 @@ class AVLPartNum:
     """DoNotChangeVendorOrPartNum"""
 
 
+@deprecation("25.2")
 class AVLDescription:
     """Constants for AVLDescription in the Update Parts List from AVL request."""
 
-    avl_description = SherlockPartsService_pb2.AVLDescription
+    avl_description = PartsService.AVLDescription
     ASSIGN_APPROVED_DESCRIPTION = avl_description.AssignApprovedDescription
     """AssignApprovedDescription"""
     DO_NOT_CHANGE_DESCRIPTION = avl_description.DoNotChangeDescription
@@ -104,8 +97,8 @@ class GetPartsListPropertiesRequest(BaseModel):
         """Validate string fields listed."""
         return basic_str_validator(value, info.field_name)
 
-    def _convert_to_grpc(self) -> SherlockPartsService_pb2.GetPartsListPropertiesRequest:
-        return SherlockPartsService_pb2.GetPartsListPropertiesRequest(
+    def _convert_to_grpc(self) -> PartsService.GetPartsListPropertiesRequest:
+        return PartsService.GetPartsListPropertiesRequest(
             project=self.project,
             ccaName=self.cca_name,
             refDes=self.reference_designators,
@@ -128,8 +121,8 @@ class UpdatePadPropertiesRequest(BaseModel):
         """Validate string fields listed."""
         return basic_str_validator(value, info.field_name)
 
-    def _convert_to_grpc(self) -> parts_service.UpdatePadPropertiesRequest:
-        return parts_service.UpdatePadPropertiesRequest(
+    def _convert_to_grpc(self) -> PartsService.UpdatePadPropertiesRequest:
+        return PartsService.UpdatePadPropertiesRequest(
             project=self.project,
             ccaName=self.cca_name,
             refDes=self.reference_designators,
@@ -152,8 +145,8 @@ class DeletePartsFromPartsListRequest(BaseModel):
         """Validate string fields listed."""
         return basic_str_validator(value, info.field_name)
 
-    def _convert_to_grpc(self) -> parts_service.DeletePartsFromPartsListRequest:
-        return parts_service.DeletePartsFromPartsListRequest(
+    def _convert_to_grpc(self) -> PartsService.DeletePartsFromPartsListRequest:
+        return PartsService.DeletePartsFromPartsListRequest(
             project=self.project,
             ccaName=self.cca_name,
             refDes=self.reference_designators,
@@ -166,7 +159,7 @@ class ImportPartsToAVLRequest(BaseModel):
     import_file: str
     """Full file path to the AVL file."""
 
-    import_type: parts_service.AVLImportType.ValueType
+    import_type: PartsService.AVLImportType.ValueType
     """Import mode to use for AVL data."""
 
     """Allow non-standard types like Protobuf enums in Pydantic models."""
@@ -180,8 +173,8 @@ class ImportPartsToAVLRequest(BaseModel):
             raise ValueError(f"{info.field_name} cannot be empty.")
         return basic_str_validator(value, info.field_name)
 
-    def _convert_to_grpc(self) -> parts_service.ImportPartsToAVLRequest:
-        request = parts_service.ImportPartsToAVLRequest()
+    def _convert_to_grpc(self) -> PartsService.ImportPartsToAVLRequest:
+        request = PartsService.ImportPartsToAVLRequest()
         request.importFile = self.import_file
         request.importType = self.import_type
         return request

--- a/src/ansys/sherlock/core/types/parts_types.py
+++ b/src/ansys/sherlock/core/types/parts_types.py
@@ -33,7 +33,7 @@ from pydantic import BaseModel, field_validator
 from ansys.sherlock.core.types.common_types import basic_str_validator, deprecation
 
 
-@deprecation("25.2")
+@deprecation("27.1")
 class PartsListSearchMatchingMode:
     """DEPRECATED. Constants for Matching Mode in Update Parts List & Update Parts from AVL."""
 
@@ -44,7 +44,7 @@ class PartsListSearchMatchingMode:
     """Part"""
 
 
-@deprecation("25.2")
+@deprecation("27.1")
 class PartsListSearchDuplicationMode:
     """Constants for Duplication Mode in Update Parts List and Update Parts from AVL request."""
 
@@ -57,7 +57,7 @@ class PartsListSearchDuplicationMode:
     """Ignore"""
 
 
-@deprecation("25.2")
+@deprecation("27.1")
 class AVLPartNum:
     """Constants for AVLPartNum in the Update Parts List from AVL request."""
 
@@ -70,7 +70,7 @@ class AVLPartNum:
     """DoNotChangeVendorOrPartNum"""
 
 
-@deprecation("25.2")
+@deprecation("27.1")
 class AVLDescription:
     """Constants for AVLDescription in the Update Parts List from AVL request."""
 

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -174,7 +174,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                 "Invalid CCA",
                 [
                     [
-                        random_vibe,
+                        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                         [
                             ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                             ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -199,7 +199,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                 "Main Board",
                 [
                     [
-                        random_vibe,
+                        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                         [
                             ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                             ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -224,7 +224,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                 "Main Board",
                 [
                     [
-                        harmonic_vibe,
+                        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.HarmonicVibe,
                         [
                             ["Phase 1", "Harmonic Vibe", "TOP", "MainBoardStrain - Top"],
                             ["Phase 1", "Harmonic Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -249,7 +249,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    random_vibe,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -268,7 +268,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "",
             [
                 [
-                    random_vibe,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -355,7 +355,12 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
         analysis.run_strain_map_analysis(
             "AssemblyTutorial",
             "Main Board",
-            [[random_vibe, event_strain_maps]],
+            [
+                [
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    event_strain_maps,
+                ]
+            ],
         )
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockRunStrainMapAnalysisError as e:
@@ -369,7 +374,12 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
         analysis.run_strain_map_analysis(
             "AssemblyTutorial",
             "Main Board",
-            [[random_vibe, event_strain_maps]],
+            [
+                [
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    event_strain_maps,
+                ]
+            ],
         )
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockRunStrainMapAnalysisError as e:
@@ -384,7 +394,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    random_vibe,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM"],
@@ -406,7 +416,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    random_vibe,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -428,7 +438,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    random_vibe,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -450,7 +460,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    random_vibe,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -458,7 +468,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                     ],
                 ],
                 [
-                    random_vibe,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -481,7 +491,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    random_vibe,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -1545,7 +1555,20 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
             analysis.update_pcb_modeling_props(
                 "Tutorial Project",
                 ["Invalid CCA"],
-                [(natural_freq, bonded, True, layered, solid_shell, 6.5, "mm", 3.2, "mm", True)],
+                [
+                    (
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                        True,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered,
+                        AnalysisService.ElementOrder.SolidShell,
+                        6.5,
+                        "mm",
+                        3.2,
+                        "mm",
+                        True,
+                    )
+                ],
             )
             pytest.fail("No exception raised when using an invalid parameter")
         except Exception as e:
@@ -1556,7 +1579,20 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
             result1 = analysis.update_pcb_modeling_props(
                 "Tutorial Project",
                 ["Main Board"],
-                [(natural_freq, bonded, True, uniform, solid_shell, 6.5, "mm", 3.2, "mm", True)],
+                [
+                    (
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                        True,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+                        AnalysisService.ElementOrder.SolidShell,
+                        6.5,
+                        "mm",
+                        3.2,
+                        "mm",
+                        True,
+                    )
+                ],
             )
             assert result1 == 0
         except SherlockUpdatePcbModelingPropsError as e:
@@ -1566,7 +1602,20 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
             result1 = analysis.update_pcb_modeling_props(
                 "Tutorial Project",
                 ["Main Board"],
-                [(natural_freq, bonded, True, uniform, solid_shell, 6.5, "mm", 3.2, "mm", True)],
+                [
+                    (
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                        True,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+                        AnalysisService.ElementOrder.SolidShell,
+                        6.5,
+                        "mm",
+                        3.2,
+                        "mm",
+                        True,
+                    )
+                ],
             )
             assert result1 == 0
         except SherlockUpdatePcbModelingPropsError as e:
@@ -1576,7 +1625,20 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
             result2 = analysis.update_pcb_modeling_props(
                 "Tutorial Project",
                 ["Main Board"],
-                [(natural_freq, bonded, True, layered, solid_shell, 6.5, "mm", 3.2, "mm", True)],
+                [
+                    (
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                        True,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered,
+                        AnalysisService.ElementOrder.SolidShell,
+                        6.5,
+                        "mm",
+                        3.2,
+                        "mm",
+                        True,
+                    )
+                ],
             )
             assert result2 == 0
         except SherlockUpdatePcbModelingPropsError as e:
@@ -1588,12 +1650,12 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
                 ["Main Board"],
                 [
                     (
-                        natural_freq,
-                        bonded,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                         True,
-                        uniform_elements,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform_ELEMENTS,
                         94,
-                        solid_shell,
+                        AnalysisService.ElementOrder.SolidShell,
                         6.5,
                         "mm",
                         3.2,
@@ -1612,12 +1674,12 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
                 ["Main Board"],
                 [
                     (
-                        natural_freq,
-                        bonded,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                         True,
-                        layered_elements,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered_ELEMENTS,
                         94,
-                        solid_shell,
+                        AnalysisService.ElementOrder.SolidShell,
                         6.5,
                         "mm",
                         3.2,

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -46,11 +46,7 @@ from ansys.sherlock.core.errors import (
 )
 from ansys.sherlock.core.types.analysis_types import (
     ComponentFailureMechanism,
-    ElementOrder,
-    ModelSource,
     PTHFatiguePropsAnalysis,
-    RunAnalysisRequestAnalysisType,
-    RunStrainMapAnalysisRequestAnalysisType,
     SemiconductorWearoutAnalysis,
     UpdateComponentFailureMechanismPropsRequest,
     UpdateLeadModelingPropsAnalysis,
@@ -59,9 +55,6 @@ from ansys.sherlock.core.types.analysis_types import (
     UpdateMechanicalPartsPropsRequest,
     UpdateMountPointsPropsAnalysis,
     UpdateMountPointsPropsRequest,
-    UpdatePcbModelingPropsRequestAnalysisType,
-    UpdatePcbModelingPropsRequestPcbMaterialModel,
-    UpdatePcbModelingPropsRequestPcbModelType,
     UpdatePottingRegionsPropsAnalysis,
     UpdatePottingRegionsPropsRequest,
     UpdatePTHFatiguePropsRequest,
@@ -109,7 +102,9 @@ def test_all():
 
 def helper_test_run_analysis(analysis: Analysis):
     """Test run_analysis API."""
-    natural_frequency_analysis_type = RunAnalysisRequestAnalysisType.NATURAL_FREQ
+    natural_frequency_analysis_type = (
+        AnalysisService.RunAnalysisRequest.Analysis.AnalysisType.NaturalFreq
+    )
 
     if analysis._is_connection_up():
         try:
@@ -172,7 +167,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                 "Invalid CCA",
                 [
                     [
-                        RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                         [
                             ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                             ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -197,7 +192,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                 "Main Board",
                 [
                     [
-                        RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                         [
                             ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                             ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -222,7 +217,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                 "Main Board",
                 [
                     [
-                        RunStrainMapAnalysisRequestAnalysisType.HARMONIC_VIBE,
+                        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.HarmonicVibe,
                         [
                             ["Phase 1", "Harmonic Vibe", "TOP", "MainBoardStrain - Top"],
                             ["Phase 1", "Harmonic Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -247,7 +242,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -266,7 +261,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "",
             [
                 [
-                    RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -355,7 +350,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     event_strain_maps,
                 ]
             ],
@@ -374,7 +369,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     event_strain_maps,
                 ]
             ],
@@ -392,7 +387,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM"],
@@ -414,7 +409,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -436,7 +431,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -458,7 +453,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -466,7 +461,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                     ],
                 ],
                 [
-                    RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -489,7 +484,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    RunStrainMapAnalysisRequestAnalysisType.RANDOM_VIBE,
+                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -515,7 +510,7 @@ def helper_test_get_harmonic_vibe_input_fields(analysis: Analysis):
         assert "require_material_assignment_enabled" in fields
         assert "model_source" not in fields
 
-        fields = analysis.get_harmonic_vibe_input_fields(ModelSource.GENERATED)
+        fields = analysis.get_harmonic_vibe_input_fields(AnalysisService.ModelSource.GENERATED)
         assert "harmonic_vibe_count" in fields
         assert "harmonic_vibe_damping" in fields
         assert "model_source" in fields
@@ -547,7 +542,7 @@ def helper_test_get_mechanical_shock_input_fields(analysis: Analysis):
         assert "natural_freq_max_units" in fields
         assert "model_source" not in fields
 
-        fields = analysis.get_mechanical_shock_input_fields(ModelSource.GENERATED)
+        fields = analysis.get_mechanical_shock_input_fields(AnalysisService.ModelSource.GENERATED)
         assert "shock_result_count" in fields
         assert "critical_strain_shock" in fields
         assert "critical_strain_shock_units" in fields
@@ -578,13 +573,13 @@ def helper_test_get_random_vibe_input_fields(analysis: Analysis):
         assert "require_material_assignment_enabled" in fields
         assert "model_source" not in fields
 
-        fields = analysis.get_random_vibe_input_fields(ModelSource.GENERATED)
+        fields = analysis.get_random_vibe_input_fields(AnalysisService.ModelSource.GENERATED)
         assert "model_source" in fields
         assert "part_validation_enabled" in fields
         assert "random_vibe_damping" in fields
         assert "require_material_assignment_enabled" in fields
 
-        fields = analysis.get_random_vibe_input_fields(ModelSource.STRAIN_MAP)
+        fields = analysis.get_random_vibe_input_fields(AnalysisService.ModelSource.STRAIN_MAP)
         assert "model_source" in fields
         assert "part_validation_enabled" in fields
         assert "random_vibe_damping" in fields
@@ -661,7 +656,7 @@ def helper_test_update_harmonic_vibe_props(analysis: Analysis):
             [
                 {
                     "cca_name": "Card",
-                    "model_source": ModelSource.STRAIN_MAP,
+                    "model_source": AnalysisService.ModelSource.STRAIN_MAP,
                     "harmonic_vibe_count": 2,
                     "harmonic_vibe_damping": "0.01, 0.05",
                     "part_validation_enabled": False,
@@ -715,7 +710,7 @@ def helper_test_update_harmonic_vibe_props(analysis: Analysis):
             "Test",
             [
                 {
-                    "model_source": ModelSource.STRAIN_MAP,
+                    "model_source": AnalysisService.ModelSource.STRAIN_MAP,
                     "harmonic_vibe_count": 2,
                     "harmonic_vibe_damping": "0.01, 0.05",
                     "part_validation_enabled": False,
@@ -746,7 +741,7 @@ def helper_test_update_harmonic_vibe_props(analysis: Analysis):
             [
                 {
                     "cca_name": "",
-                    "model_source": ModelSource.STRAIN_MAP,
+                    "model_source": AnalysisService.ModelSource.STRAIN_MAP,
                     "harmonic_vibe_count": 2,
                     "harmonic_vibe_damping": "0.01, 0.05",
                     "part_validation_enabled": False,
@@ -777,7 +772,7 @@ def helper_test_update_harmonic_vibe_props(analysis: Analysis):
             [
                 {
                     "cca_name": "Card",
-                    "model_source": ModelSource.STRAIN_MAP,
+                    "model_source": AnalysisService.ModelSource.STRAIN_MAP,
                     "harmonic_vibe_count": 2,
                     "harmonic_vibe_damping": "0.01, foo",
                     "part_validation_enabled": False,
@@ -809,7 +804,7 @@ def helper_test_update_harmonic_vibe_props(analysis: Analysis):
                 [
                     {
                         "cca_name": "Main Board",
-                        "model_source": ModelSource.STRAIN_MAP,
+                        "model_source": AnalysisService.ModelSource.STRAIN_MAP,
                         "harmonic_vibe_count": 2,
                         "harmonic_vibe_damping": "0.01, 0.02",
                         "part_validation_enabled": False,
@@ -837,7 +832,7 @@ def helper_test_update_harmonic_vibe_props(analysis: Analysis):
                 [
                     {
                         "cca_name": "Main Board",
-                        "model_source": ModelSource.STRAIN_MAP,
+                        "model_source": AnalysisService.ModelSource.STRAIN_MAP,
                         "harmonic_vibe_count": 4,
                         "harmonic_vibe_damping": "0.015, 0.025",
                         "part_validation_enabled": True,
@@ -864,7 +859,7 @@ def helper_test_set_update_harmonic_vibe_props_request_properties(analysis: Anal
     properties = [
         {
             "cca_name": "Main Board",
-            "model_source": ModelSource.STRAIN_MAP,
+            "model_source": AnalysisService.ModelSource.STRAIN_MAP,
             "harmonic_vibe_count": 4,
             "harmonic_vibe_damping": "0.015, 0.025",
             "part_validation_enabled": True,
@@ -888,7 +883,7 @@ def helper_test_set_update_harmonic_vibe_props_request_properties(analysis: Anal
     analysis._set_update_harmonic_vibe_props_request_properties(mock_request, properties)
 
     assert mock_hv_properties.ccaName == "Main Board"
-    assert mock_hv_properties.modelSource == ModelSource.STRAIN_MAP
+    assert mock_hv_properties.modelSource == AnalysisService.ModelSource.STRAIN_MAP
     assert mock_hv_properties.harmonicVibeCount == 4
     assert mock_hv_properties.harmonicVibeDamping == "0.015, 0.025"
     assert mock_hv_properties.partValidationEnabled == True
@@ -1355,7 +1350,7 @@ def helper_test_update_random_vibe_props(analysis: Analysis):
             "Test",
             "Card",
             random_vibe_damping="0.01, 0.02",
-            model_source=ModelSource.STRAIN_MAP,
+            model_source=AnalysisService.ModelSource.STRAIN_MAP,
             strain_map_natural_freqs=None,
         )
         pytest.fail("No exception raised when using an invalid parameter")
@@ -1371,7 +1366,7 @@ def helper_test_update_random_vibe_props(analysis: Analysis):
                 random_vibe_damping="0.01, 0.02",
                 part_validation_enabled=True,
                 require_material_assignment_enabled=False,
-                model_source=ModelSource.STRAIN_MAP,
+                model_source=AnalysisService.ModelSource.STRAIN_MAP,
                 strain_map_natural_freqs=invalid_strain_map_natural_freqs,
             )
             pytest.fail("No exception raised when using an invalid parameter")
@@ -1385,7 +1380,7 @@ def helper_test_update_random_vibe_props(analysis: Analysis):
                 random_vibe_damping="0.01, 0.02",
                 part_validation_enabled=True,
                 require_material_assignment_enabled=False,
-                model_source=ModelSource.GENERATED,
+                model_source=AnalysisService.ModelSource.GENERATED,
                 strain_map_natural_freqs="101, 201, 501, 1001",
             )
             assert result == 0
@@ -1484,11 +1479,11 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
             ["Main Board"],
             [
                 (
-                    UpdatePcbModelingPropsRequestAnalysisType.NATURAL_FREQUENCY,
-                    UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                    AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                    AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                     True,
-                    UpdatePcbModelingPropsRequestPcbMaterialModel.UNIFORM,
-                    ElementOrder.SOLID_SHELL,
+                    AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+                    AnalysisService.ElementOrder.SolidShell,
                     6.5,
                     "mm",
                     3.2,
@@ -1541,11 +1536,11 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
                 ["Invalid CCA"],
                 [
                     (
-                        UpdatePcbModelingPropsRequestAnalysisType.NATURAL_FREQUENCY,
-                        UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                         True,
-                        UpdatePcbModelingPropsRequestPcbMaterialModel.LAYERED,
-                        ElementOrder.SOLID_SHELL,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered,
+                        AnalysisService.ElementOrder.SolidShell,
                         6.5,
                         "mm",
                         3.2,
@@ -1565,11 +1560,11 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
                 ["Main Board"],
                 [
                     (
-                        UpdatePcbModelingPropsRequestAnalysisType.NATURAL_FREQUENCY,
-                        UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                         True,
-                        UpdatePcbModelingPropsRequestPcbMaterialModel.UNIFORM,
-                        ElementOrder.SOLID_SHELL,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+                        AnalysisService.ElementOrder.SolidShell,
                         6.5,
                         "mm",
                         3.2,
@@ -1588,11 +1583,11 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
                 ["Main Board"],
                 [
                     (
-                        UpdatePcbModelingPropsRequestAnalysisType.NATURAL_FREQUENCY,
-                        UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                         True,
-                        UpdatePcbModelingPropsRequestPcbMaterialModel.UNIFORM,
-                        ElementOrder.SOLID_SHELL,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
+                        AnalysisService.ElementOrder.SolidShell,
                         6.5,
                         "mm",
                         3.2,
@@ -1611,11 +1606,11 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
                 ["Main Board"],
                 [
                     (
-                        UpdatePcbModelingPropsRequestAnalysisType.NATURAL_FREQUENCY,
-                        UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                         True,
-                        UpdatePcbModelingPropsRequestPcbMaterialModel.LAYERED,
-                        ElementOrder.SOLID_SHELL,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered,
+                        AnalysisService.ElementOrder.SolidShell,
                         6.5,
                         "mm",
                         3.2,
@@ -1634,12 +1629,12 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
                 ["Main Board"],
                 [
                     (
-                        UpdatePcbModelingPropsRequestAnalysisType.NATURAL_FREQUENCY,
-                        UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                         True,
-                        UpdatePcbModelingPropsRequestPcbMaterialModel.UNIFORM_ELEMENTS,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform_ELEMENTS,
                         94,
-                        ElementOrder.SOLID_SHELL,
+                        AnalysisService.ElementOrder.SolidShell,
                         6.5,
                         "mm",
                         3.2,
@@ -1658,12 +1653,12 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
                 ["Main Board"],
                 [
                     (
-                        UpdatePcbModelingPropsRequestAnalysisType.NATURAL_FREQUENCY,
-                        UpdatePcbModelingPropsRequestPcbModelType.BONDED,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
                         True,
-                        UpdatePcbModelingPropsRequestPcbMaterialModel.LAYERED_ELEMENTS,
+                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered_ELEMENTS,
                         94,
-                        ElementOrder.SOLID_SHELL,
+                        AnalysisService.ElementOrder.SolidShell,
                         6.5,
                         "mm",
                         3.2,

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -174,7 +174,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                 "Invalid CCA",
                 [
                     [
-                        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                        random_vibe,
                         [
                             ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                             ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -199,7 +199,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                 "Main Board",
                 [
                     [
-                        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                        random_vibe,
                         [
                             ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                             ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -224,7 +224,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                 "Main Board",
                 [
                     [
-                        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.HarmonicVibe,
+                        harmonic_vibe,
                         [
                             ["Phase 1", "Harmonic Vibe", "TOP", "MainBoardStrain - Top"],
                             ["Phase 1", "Harmonic Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -249,7 +249,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -268,7 +268,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -355,12 +355,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
         analysis.run_strain_map_analysis(
             "AssemblyTutorial",
             "Main Board",
-            [
-                [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
-                    event_strain_maps,
-                ]
-            ],
+            [[random_vibe, event_strain_maps]],
         )
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockRunStrainMapAnalysisError as e:
@@ -374,12 +369,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
         analysis.run_strain_map_analysis(
             "AssemblyTutorial",
             "Main Board",
-            [
-                [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
-                    event_strain_maps,
-                ]
-            ],
+            [[random_vibe, event_strain_maps]],
         )
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockRunStrainMapAnalysisError as e:
@@ -394,7 +384,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM"],
@@ -416,7 +406,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -438,7 +428,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -460,7 +450,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -468,7 +458,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                     ],
                 ],
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -491,7 +481,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -1555,20 +1545,7 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
             analysis.update_pcb_modeling_props(
                 "Tutorial Project",
                 ["Invalid CCA"],
-                [
-                    (
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                        True,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered,
-                        AnalysisService.ElementOrder.SolidShell,
-                        6.5,
-                        "mm",
-                        3.2,
-                        "mm",
-                        True,
-                    )
-                ],
+                [(natural_freq, bonded, True, layered, solid_shell, 6.5, "mm", 3.2, "mm", True)],
             )
             pytest.fail("No exception raised when using an invalid parameter")
         except Exception as e:
@@ -1579,20 +1556,7 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
             result1 = analysis.update_pcb_modeling_props(
                 "Tutorial Project",
                 ["Main Board"],
-                [
-                    (
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                        True,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
-                        AnalysisService.ElementOrder.SolidShell,
-                        6.5,
-                        "mm",
-                        3.2,
-                        "mm",
-                        True,
-                    )
-                ],
+                [(natural_freq, bonded, True, uniform, solid_shell, 6.5, "mm", 3.2, "mm", True)],
             )
             assert result1 == 0
         except SherlockUpdatePcbModelingPropsError as e:
@@ -1602,20 +1566,7 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
             result1 = analysis.update_pcb_modeling_props(
                 "Tutorial Project",
                 ["Main Board"],
-                [
-                    (
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                        True,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
-                        AnalysisService.ElementOrder.SolidShell,
-                        6.5,
-                        "mm",
-                        3.2,
-                        "mm",
-                        True,
-                    )
-                ],
+                [(natural_freq, bonded, True, uniform, solid_shell, 6.5, "mm", 3.2, "mm", True)],
             )
             assert result1 == 0
         except SherlockUpdatePcbModelingPropsError as e:
@@ -1625,20 +1576,7 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
             result2 = analysis.update_pcb_modeling_props(
                 "Tutorial Project",
                 ["Main Board"],
-                [
-                    (
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                        True,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered,
-                        AnalysisService.ElementOrder.SolidShell,
-                        6.5,
-                        "mm",
-                        3.2,
-                        "mm",
-                        True,
-                    )
-                ],
+                [(natural_freq, bonded, True, layered, solid_shell, 6.5, "mm", 3.2, "mm", True)],
             )
             assert result2 == 0
         except SherlockUpdatePcbModelingPropsError as e:
@@ -1650,12 +1588,12 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
                 ["Main Board"],
                 [
                     (
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                        natural_freq,
+                        bonded,
                         True,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform_ELEMENTS,
+                        uniform_elements,
                         94,
-                        AnalysisService.ElementOrder.SolidShell,
+                        solid_shell,
                         6.5,
                         "mm",
                         3.2,
@@ -1674,12 +1612,12 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
                 ["Main Board"],
                 [
                     (
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                        natural_freq,
+                        bonded,
                         True,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered_ELEMENTS,
+                        layered_elements,
                         94,
-                        AnalysisService.ElementOrder.SolidShell,
+                        solid_shell,
                         6.5,
                         "mm",
                         3.2,

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -160,6 +160,13 @@ def helper_test_run_analysis(analysis: Analysis):
 
 def helper_test_run_strain_map_analysis(analysis: Analysis):
     """Test run_strain_map_analysis API."""
+    random_vibe = (
+        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe
+    )
+    harmonic_vibe = (
+        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.HarmonicVibe
+    )
+
     if analysis._is_connection_up():
         try:
             analysis.run_strain_map_analysis(
@@ -167,7 +174,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                 "Invalid CCA",
                 [
                     [
-                        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                        random_vibe,
                         [
                             ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                             ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -192,7 +199,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                 "Main Board",
                 [
                     [
-                        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                        random_vibe,
                         [
                             ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                             ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -217,7 +224,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                 "Main Board",
                 [
                     [
-                        AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.HarmonicVibe,
+                        harmonic_vibe,
                         [
                             ["Phase 1", "Harmonic Vibe", "TOP", "MainBoardStrain - Top"],
                             ["Phase 1", "Harmonic Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -242,7 +249,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -261,7 +268,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -348,12 +355,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
         analysis.run_strain_map_analysis(
             "AssemblyTutorial",
             "Main Board",
-            [
-                [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
-                    event_strain_maps,
-                ]
-            ],
+            [[random_vibe, event_strain_maps]],
         )
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockRunStrainMapAnalysisError as e:
@@ -367,12 +369,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
         analysis.run_strain_map_analysis(
             "AssemblyTutorial",
             "Main Board",
-            [
-                [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
-                    event_strain_maps,
-                ]
-            ],
+            [[random_vibe, event_strain_maps]],
         )
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockRunStrainMapAnalysisError as e:
@@ -387,7 +384,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM"],
@@ -409,7 +406,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -431,7 +428,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -453,7 +450,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -461,7 +458,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
                     ],
                 ],
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -484,7 +481,7 @@ def helper_test_run_strain_map_analysis(analysis: Analysis):
             "Main Board",
             [
                 [
-                    AnalysisService.RunStrainMapAnalysisRequest.StrainMapAnalysis.AnalysisType.RandomVibe,
+                    random_vibe,
                     [
                         ["Phase 1", "Random Vibe", "TOP", "MainBoardStrain - Top"],
                         ["Phase 1", "Random Vibe", "BOTTOM", "MainBoardStrain - Bottom"],
@@ -1530,24 +1527,25 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
         assert str(e) == "Update PCB Modeling Error: Analysis input(s) are invalid."
 
     if analysis._is_connection_up():
+        natural_freq = (
+            AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq
+        )
+        bonded = AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded
+        layered = AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered
+        uniform = AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform
+        uniform_elements = (
+            AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform_ELEMENTS
+        )
+        layered_elements = (
+            AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered_ELEMENTS
+        )
+        solid_shell = AnalysisService.ElementOrder.SolidShell
+
         try:
             analysis.update_pcb_modeling_props(
                 "Tutorial Project",
                 ["Invalid CCA"],
-                [
-                    (
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                        True,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered,
-                        AnalysisService.ElementOrder.SolidShell,
-                        6.5,
-                        "mm",
-                        3.2,
-                        "mm",
-                        True,
-                    )
-                ],
+                [(natural_freq, bonded, True, layered, solid_shell, 6.5, "mm", 3.2, "mm", True)],
             )
             pytest.fail("No exception raised when using an invalid parameter")
         except Exception as e:
@@ -1558,20 +1556,7 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
             result1 = analysis.update_pcb_modeling_props(
                 "Tutorial Project",
                 ["Main Board"],
-                [
-                    (
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                        True,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
-                        AnalysisService.ElementOrder.SolidShell,
-                        6.5,
-                        "mm",
-                        3.2,
-                        "mm",
-                        True,
-                    )
-                ],
+                [(natural_freq, bonded, True, uniform, solid_shell, 6.5, "mm", 3.2, "mm", True)],
             )
             assert result1 == 0
         except SherlockUpdatePcbModelingPropsError as e:
@@ -1581,20 +1566,7 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
             result1 = analysis.update_pcb_modeling_props(
                 "Tutorial Project",
                 ["Main Board"],
-                [
-                    (
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                        True,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform,
-                        AnalysisService.ElementOrder.SolidShell,
-                        6.5,
-                        "mm",
-                        3.2,
-                        "mm",
-                        True,
-                    )
-                ],
+                [(natural_freq, bonded, True, uniform, solid_shell, 6.5, "mm", 3.2, "mm", True)],
             )
             assert result1 == 0
         except SherlockUpdatePcbModelingPropsError as e:
@@ -1604,20 +1576,7 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
             result2 = analysis.update_pcb_modeling_props(
                 "Tutorial Project",
                 ["Main Board"],
-                [
-                    (
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
-                        True,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered,
-                        AnalysisService.ElementOrder.SolidShell,
-                        6.5,
-                        "mm",
-                        3.2,
-                        "mm",
-                        True,
-                    )
-                ],
+                [(natural_freq, bonded, True, layered, solid_shell, 6.5, "mm", 3.2, "mm", True)],
             )
             assert result2 == 0
         except SherlockUpdatePcbModelingPropsError as e:
@@ -1629,12 +1588,12 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
                 ["Main Board"],
                 [
                     (
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                        natural_freq,
+                        bonded,
                         True,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Uniform_ELEMENTS,
+                        uniform_elements,
                         94,
-                        AnalysisService.ElementOrder.SolidShell,
+                        solid_shell,
                         6.5,
                         "mm",
                         3.2,
@@ -1653,12 +1612,12 @@ def helper_test_update_pcb_modeling_props(analysis: Analysis):
                 ["Main Board"],
                 [
                     (
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.AnalysisType.NaturalFreq,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbModelType.Bonded,
+                        natural_freq,
+                        bonded,
                         True,
-                        AnalysisService.UpdatePcbModelingPropsRequest.Analysis.PcbMaterialModel.Layered_ELEMENTS,
+                        layered_elements,
                         94,
-                        AnalysisService.ElementOrder.SolidShell,
+                        solid_shell,
                         6.5,
                         "mm",
                         3.2,

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -23,6 +23,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import importlib
+
 import grpc
 import pytest
 
@@ -30,6 +32,18 @@ from ansys.sherlock.core.common import Common
 from ansys.sherlock.core.errors import SherlockCommonServiceError
 from ansys.sherlock.core.types.common_types import ListUnitsRequestUnitType
 from ansys.sherlock.core.utils.version_check import SKIP_VERSION_CHECK
+
+
+def test_proto_enum_wrapper_deprecation_warning():
+    """Deprecated enum wrapper classes should warn with the 25.2 deprecation version."""
+    import ansys.sherlock.core.types.analysis_types as analysis_types_module
+    import ansys.sherlock.core.types.parts_types as parts_types_module
+
+    with pytest.warns(DeprecationWarning, match=r"25\.2.*proto"):
+        importlib.reload(analysis_types_module)
+
+    with pytest.warns(DeprecationWarning, match=r"25\.2.*proto"):
+        importlib.reload(parts_types_module)
 
 
 def test_all():

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -35,14 +35,14 @@ from ansys.sherlock.core.utils.version_check import SKIP_VERSION_CHECK
 
 
 def test_proto_enum_wrapper_deprecation_warning():
-    """Deprecated enum wrapper classes should warn with the 25.2 deprecation version."""
+    """Deprecated enum wrapper classes should warn with the 27.1 deprecation version."""
     import ansys.sherlock.core.types.analysis_types as analysis_types_module
     import ansys.sherlock.core.types.parts_types as parts_types_module
 
-    with pytest.warns(DeprecationWarning, match=r"25\.2.*proto"):
+    with pytest.warns(DeprecationWarning, match=r"27\.1.*proto"):
         importlib.reload(analysis_types_module)
 
-    with pytest.warns(DeprecationWarning, match=r"25\.2.*proto"):
+    with pytest.warns(DeprecationWarning, match=r"27\.1.*proto"):
         importlib.reload(parts_types_module)
 
 

--- a/tests/test_parts.py
+++ b/tests/test_parts.py
@@ -46,12 +46,9 @@ from ansys.sherlock.core.errors import (
 from ansys.sherlock.core.parts import Parts
 from ansys.sherlock.core.types.common_types import TableDelimiter
 from ansys.sherlock.core.types.parts_types import (
-    AVLDescription,
-    AVLPartNum,
     DeletePartsFromPartsListRequest,
     GetPartsListPropertiesRequest,
     ImportPartsToAVLRequest,
-    PartsListSearchDuplicationMode,
     UpdatePadPropertiesRequest,
 )
 from ansys.sherlock.core.utils.version_check import SKIP_VERSION_CHECK
@@ -89,7 +86,7 @@ def helper_test_update_parts_list(parts: Parts):
                 "Main Board",
                 "Sherlock Part Library",
                 "Both",
-                PartsListSearchDuplicationMode.ERROR,
+                SherlockPartsService_pb2.DuplicationMode.Error,
             )
             assert result == 0
         except Exception as e:
@@ -101,7 +98,7 @@ def helper_test_update_parts_list(parts: Parts):
                 "Invalid CCA",
                 "Sherlock Part Library",
                 "Both",
-                PartsListSearchDuplicationMode.ERROR,
+                SherlockPartsService_pb2.DuplicationMode.Error,
             )
             pytest.fail("No exception raised when using an invalid parameter")
         except Exception as e:
@@ -113,7 +110,7 @@ def helper_test_update_parts_list(parts: Parts):
             "Card",
             "Sherlock Part Library",
             "Both",
-            PartsListSearchDuplicationMode.ERROR,
+            SherlockPartsService_pb2.DuplicationMode.Error,
         )
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockUpdatePartsListError as e:
@@ -125,7 +122,7 @@ def helper_test_update_parts_list(parts: Parts):
             "",
             "Sherlock Part Library",
             "Both",
-            PartsListSearchDuplicationMode.ERROR,
+            SherlockPartsService_pb2.DuplicationMode.Error,
         )
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockUpdatePartsListError as e:
@@ -137,7 +134,7 @@ def helper_test_update_parts_list(parts: Parts):
             "Card",
             "",
             "Both",
-            PartsListSearchDuplicationMode.ERROR,
+            SherlockPartsService_pb2.DuplicationMode.Error,
         )
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockUpdatePartsListError as e:
@@ -155,7 +152,7 @@ def helper_test_update_parts_list(parts: Parts):
                     "Card",
                     "Sherlock Part Library",
                     "Both",
-                    PartsListSearchDuplicationMode.ERROR,
+                    SherlockPartsService_pb2.DuplicationMode.Error,
                 )
                 pytest.fail("No exception raised when server returns errors")
             except SherlockUpdatePartsListError as e:
@@ -168,9 +165,9 @@ def helper_test_update_parts_from_AVL(parts: Parts):
             project="",
             cca_name="Main Board",
             matching_mode="Both",
-            duplication_mode=PartsListSearchDuplicationMode.FIRST,
-            avl_part_num=AVLPartNum.ASSIGN_INTERNAL_PART_NUM,
-            avl_description=AVLDescription.ASSIGN_APPROVED_DESCRIPTION,
+            duplication_mode=SherlockPartsService_pb2.DuplicationMode.First,
+            avl_part_num=SherlockPartsService_pb2.AVLPartNum.AssignInternalPartNum,
+            avl_description=SherlockPartsService_pb2.AVLDescription.AssignApprovedDescription,
         )
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockUpdatePartsFromAVLError as e:
@@ -181,9 +178,9 @@ def helper_test_update_parts_from_AVL(parts: Parts):
             project="Tutorial Project",
             cca_name="",
             matching_mode="Both",
-            duplication_mode=PartsListSearchDuplicationMode.FIRST,
-            avl_part_num=AVLPartNum.ASSIGN_INTERNAL_PART_NUM,
-            avl_description=AVLDescription.ASSIGN_APPROVED_DESCRIPTION,
+            duplication_mode=SherlockPartsService_pb2.DuplicationMode.First,
+            avl_part_num=SherlockPartsService_pb2.AVLPartNum.AssignInternalPartNum,
+            avl_description=SherlockPartsService_pb2.AVLDescription.AssignApprovedDescription,
         )
         pytest.fail("No exception raised when using an invalid parameter")
     except SherlockUpdatePartsFromAVLError as e:
@@ -195,9 +192,9 @@ def helper_test_update_parts_from_AVL(parts: Parts):
                 project="Tutorial Project",
                 cca_name="Main Board",
                 matching_mode="Both",
-                duplication_mode=PartsListSearchDuplicationMode.FIRST,
-                avl_part_num=AVLPartNum.ASSIGN_INTERNAL_PART_NUM,
-                avl_description=AVLDescription.ASSIGN_APPROVED_DESCRIPTION,
+                duplication_mode=SherlockPartsService_pb2.DuplicationMode.First,
+                avl_part_num=SherlockPartsService_pb2.AVLPartNum.AssignInternalPartNum,
+                avl_description=SherlockPartsService_pb2.AVLDescription.AssignApprovedDescription,
             )
 
             assert response == 0


### PR DESCRIPTION
## Description
Deprecate constants that are wrappers of enums that are defined in the .proto files. It is preferable to use the enums as defined in the .proto files and document this usage using type hints.

The classes removed are listed here.
analysis_types.py

ElementOrder
ModelSource
RunAnalysisRequestAnalysisType
RunStrainMapAnalysisRequestAnalysisType
UpdatePcbModelingPropsRequestAnalysisType
UpdatePcbModelingPropsRequestPcbMaterialModel
UpdatePcbModelingPropsRequestPcbModelType
parts_types.py

PartsListSearchDuplicationMode
AVLPartNum
AVLDescription

## Issue linked
#551 #746 

## Checklist:
- [x] Run unit tests and make sure they all pass
		- Run tests without Sherlock running
		- Run tests with Sherlock GRPC connection
- [x] Check and fix style errors
		- pre-commit command line check
		- Problems tab in PyCharm
- [x] Bench test new/modified APIs by using and modifying the code in the example for the API method
- [ ] Add new classes to rst files, located at: <pysherlock>\doc\source\api
- [x] Generate documentation
- [x] Verify the HTML. It gets generated at: <pysherlock>\doc\build\html.
		- Open index.html
		- Click on "API Reference" at the top.
		- Verify HTML for API changes.
- [x] Check that test code coverage is at least 80% when Sherlock is running
- [x] Check vulnerabilities locally
- [x] Make sure that the title of the pull request follows [Commit naming conventions](https://dev.docs.pyansys.com/how-to/contributing.html#commit-naming-conventions) (e.g. ``feat: adding new PySherlock command``)
